### PR TITLE
feat(api): add v1 hardening and docker support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Sample configuration for gepa-next
+OPENROUTER_API_KEY=dev
+API_BEARER_TOKENS='["token"]'
+MAX_REQUEST_BYTES=1048576
+RATE_LIMIT_PER_MIN=60
+RATE_LIMIT_BURST=30
+JOB_STORE=memory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim AS builder
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --prefix=/install --no-cache-dir -r requirements.txt
+COPY . .
+
+FROM python:3.11-slim
+WORKDIR /app
+COPY --from=builder /install /usr/local
+COPY . .
+USER 1000
+EXPOSE 8000
+CMD ["uvicorn", "innerloop.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: run lint typecheck test qa docker-build docker-run
+
+run:
+uvicorn innerloop.main:app --reload
+
+lint:
+ruff .
+
+typecheck:
+mypy .
+
+test:
+python -m pytest -q
+
+qa: lint typecheck test
+
+docker-build:
+docker build -t gepa-next .
+
+docker-run:
+docker run -p 8000:8000 gepa-next

--- a/PERFORMANCE_CHECKLIST.md
+++ b/PERFORMANCE_CHECKLIST.md
@@ -4,7 +4,7 @@
 1. Run with `uvicorn --http h11 --loop uvloop` (if available).
 2. Use appropriate worker count: `workers = CPU cores` for CPU-bound, more for I/O.
 3. Keep requests under `MAX_REQUEST_BYTES` (~64 KB default).
-4. Enforce per-IP rate limiting on `POST /optimize`.
+4. Enforce per-token rate limiting on `POST /v1/optimize`.
 5. Avoid blocking calls; use `asyncio` all the way.
 6. SSE queues are bounded; jobs fail after `SSE_BACKPRESSURE_FAIL_TIMEOUT_S`.
 7. JSON serialization uses compact separators; consider `orjson` for heavy loads.
@@ -84,7 +84,7 @@ Prevents memory leaks and keeps steady-state footprint predictable.
 ## 6. Rate limiting & Request limits
 **Checklist**
 - `MAX_REQUEST_BYTES` guards large payloads.
-- Token bucket rate limiting via `RATE_LIMIT_OPTIMIZE_*`.
+- Token bucket rate limiting via `RATE_LIMIT_PER_MIN` and `RATE_LIMIT_BURST`.
 
 **Why it matters**
 Protects service from overload by large or excessive requests.

--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ pip install -r requirements.txt
 export OPENROUTER_API_KEY=dev
 uvicorn innerloop.main:app --reload
 
-# create a job
-curl -s -X POST "http://127.0.0.1:8000/optimize?iterations=1"
+# create a job (v1 API)
+curl -s -X POST "http://127.0.0.1:8000/v1/optimize?iterations=1" -H "Idempotency-Key: demo-1"
 
 # stream events
-curl -N "http://127.0.0.1:8000/optimize/<job_id>/events"
+curl -N "http://127.0.0.1:8000/v1/optimize/<job_id>/events"
+
+# resume a stream using Last-Event-ID
+curl -N -H "Last-Event-ID: 5" "http://127.0.0.1:8000/v1/optimize/<job_id>/events"
 ```

--- a/SECURITY_CHECKLIST.md
+++ b/SECURITY_CHECKLIST.md
@@ -3,7 +3,7 @@
 ## Security Quick Start – Top 10
 1. Require auth (`REQUIRE_AUTH`) and keep bearer tokens rotated.
 2. Never log secrets; Authorization headers are redacted and request IDs added.
-3. Enforce per-IP rate limiting on `POST /optimize`.
+3. Enforce per-token rate limiting on `POST /v1/optimize`.
 4. Drop requests with bodies over `MAX_REQUEST_BYTES` (~64 KB default).
 5. Clamp job iterations to `MAX_ITERATIONS` to avoid runaway loops.
 6. Limit SSE queue size (`SSE_QUEUE_MAXSIZE`) and fail after `SSE_BACKPRESSURE_FAIL_TIMEOUT_S`.
@@ -72,7 +72,7 @@ Stops resource exhaustion and unexpected code paths.
 
 ## 5. Rate Limiting / DoS Resilience
 **Checklist**
-- Per-IP token bucket on `POST /optimize`.
+- Token bucket keyed by bearer token (or anonymous-openrouter) on `POST /v1/optimize`.
 - Bounded SSE queue (`SSE_QUEUE_MAXSIZE`).
 
 **Why it matters**

--- a/innerloop/api/middleware/deprecation.py
+++ b/innerloop/api/middleware/deprecation.py
@@ -23,6 +23,6 @@ class DeprecationMiddleware(BaseHTTPMiddleware):
         for old, new in self._map.items():
             if path == old or path.startswith(old + "/"):
                 response.headers["Deprecation"] = "true"
-                response.headers["Link"] = f"<{new}>; rel=\"successor-version\""
+                response.headers["Link"] = f'<{new}>; rel="successor-version"'
                 break
         return response

--- a/innerloop/api/middleware/deprecation.py
+++ b/innerloop/api/middleware/deprecation.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class DeprecationMiddleware(BaseHTTPMiddleware):
+    """Adds Deprecation headers to legacy unversioned routes."""
+
+    def __init__(self, app) -> None:
+        super().__init__(app)
+        self._map = {
+            "/healthz": "/v1/healthz",
+            "/readyz": "/v1/readyz",
+            "/optimize": "/v1/optimize",
+        }
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Response]) -> Response:
+        response = await call_next(request)
+        path = request.url.path
+        for old, new in self._map.items():
+            if path == old or path.startswith(old + "/"):
+                response.headers["Deprecation"] = "true"
+                response.headers["Link"] = f"<{new}>; rel=\"successor-version\""
+                break
+        return response

--- a/innerloop/api/routers/admin.py
+++ b/innerloop/api/routers/admin.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Request, Response
+from fastapi.responses import JSONResponse
 
-from ..jobs.registry import JobRegistry
+from ..jobs.registry import JobRegistry, JobStatus
+from ..models import ErrorResponse
 
 router = APIRouter()
 
@@ -24,6 +26,22 @@ async def list_jobs(request: Request) -> dict:
     }
 
 
+@router.get("/jobs/{job_id}")
+async def get_job(request: Request, job_id: str):
+    store = request.app.state.store
+    record = await store.get_job(job_id)
+    if not record:
+        err = ErrorResponse(code="not_found", message="Job not found", request_id=request.state.request_id)
+        return JSONResponse(err.model_dump(), status_code=404)
+    return {
+        "job_id": record["id"],
+        "status": record["status"],
+        "created_at": record["created_at"],
+        "updated_at": record["updated_at"],
+        "result": record.get("result"),
+    }
+
+
 @router.delete("/jobs/{job_id}", status_code=204)
 async def delete_job(request: Request, job_id: str) -> Response:
     registry: JobRegistry = request.app.state.registry
@@ -32,3 +50,17 @@ async def delete_job(request: Request, job_id: str) -> Response:
         registry.jobs.pop(job_id, None)
     await store.delete_job(job_id)
     return Response(status_code=204)
+
+
+@router.post("/jobs/{job_id}/cancel")
+async def cancel_job(request: Request, job_id: str):
+    registry: JobRegistry = request.app.state.registry
+    job = registry.jobs.get(job_id)
+    if not job:
+        err = ErrorResponse(code="not_found", message="Job not found", request_id=request.state.request_id)
+        return JSONResponse(err.model_dump(), status_code=404)
+    if job.status != JobStatus.RUNNING:
+        err = ErrorResponse(code="not_cancelable", message="Job not cancelable", request_id=request.state.request_id)
+        return JSONResponse(err.model_dump(), status_code=409)
+    await registry.cancel_job(job_id)
+    return {"job_id": job_id, "status": job.status.value}

--- a/innerloop/main.py
+++ b/innerloop/main.py
@@ -11,6 +11,7 @@ from .api.middleware.auth import AuthMiddleware
 from .api.middleware.logging import LoggingMiddleware
 from .api.middleware.ratelimit import RateLimitMiddleware
 from .api.middleware.limits import SizeLimitMiddleware
+from .api.middleware.deprecation import DeprecationMiddleware
 from .api.routers.health import router as health_router
 from .api.routers.optimize import router as optimize_router
 from .api.routers.admin import router as admin_router
@@ -55,6 +56,7 @@ def create_app() -> FastAPI:
     app.add_middleware(SizeLimitMiddleware)
     app.add_middleware(RateLimitMiddleware)
     app.add_middleware(AuthMiddleware)
+    app.add_middleware(DeprecationMiddleware)
     app.add_middleware(LoggingMiddleware)
 
     # Versioned routers

--- a/innerloop/settings.py
+++ b/innerloop/settings.py
@@ -20,8 +20,11 @@ class Settings(BaseSettings):
     SSE_BUFFER_SIZE: int = 200
     MAX_ITERATIONS: int = 10
     MAX_REQUEST_BYTES: int = 64_000
-    RATE_LIMIT_OPTIMIZE_RPS: float = 2.0
-    RATE_LIMIT_OPTIMIZE_BURST: int = 5
+    RATE_LIMIT_PER_MIN: int = 60
+    RATE_LIMIT_BURST: int = 30
+    # legacy names for backward compatibility
+    RATE_LIMIT_OPTIMIZE_RPS: float | None = None
+    RATE_LIMIT_OPTIMIZE_BURST: int | None = None
     JOB_REAPER_INTERVAL_S: float = 2.0
     JOB_TTL_FINISHED_S: float = 30.0
     JOB_TTL_FAILED_S: float = 120.0
@@ -47,6 +50,11 @@ def get_settings() -> Settings:
     settings = _get_settings()
     if "SSE_BACKPRESSURE_FAIL_TIMEOUT_S" not in os.environ:
         settings.SSE_BACKPRESSURE_FAIL_TIMEOUT_S = settings.SSE_PING_INTERVAL_S * 2
+    # map legacy rate limit settings if provided
+    if settings.RATE_LIMIT_OPTIMIZE_RPS is not None:
+        settings.RATE_LIMIT_PER_MIN = int(settings.RATE_LIMIT_OPTIMIZE_RPS * 60)
+    if settings.RATE_LIMIT_OPTIMIZE_BURST is not None:
+        settings.RATE_LIMIT_BURST = settings.RATE_LIMIT_OPTIMIZE_BURST
     return settings
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic-settings>=2.3
 pytest>=8.2
 pytest-timeout>=2.3
 httpx>=0.27
+aiosqlite>=0.20


### PR DESCRIPTION
## Summary
- implement token-based rate limiting for /v1/optimize and legacy paths
- add deprecation middleware for unversioned routes and expand admin endpoints
- ship Dockerfile, Makefile, env example, and docs updates

## Testing
- `python -m pytest tests/test_healthz.py tests/test_sse_resume.py tests/test_admin.py tests/test_security_perf.py -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bc06a01f48332aa0ec6afa0e81905