### PR TITLE
feat: add tournament selection and retrieval

### DIFF
--- a/clients/python/gepa_client/client.py
+++ b/clients/python/gepa_client/client.py
@@ -19,7 +19,17 @@ class JobState(BaseModel):
 
 
 class SSEEnvelope(BaseModel):
-    type: Literal["started", "progress", "finished", "failed", "cancelled", "shutdown"]
+    type: Literal[
+        "started",
+        "progress",
+        "mutation",
+        "selected",
+        "early_stop",
+        "finished",
+        "failed",
+        "cancelled",
+        "shutdown",
+    ]
     schema_version: int = 1
     job_id: str
     ts: float

--- a/innerloop/api/models/schemas.py
+++ b/innerloop/api/models/schemas.py
@@ -57,6 +57,9 @@ class OptimizeRequest(BaseModel):
     model_id: str | None = None
     temperature: float | None = None
     max_tokens: int | None = None
+    tournament_size: int | None = None
+    recombination_rate: float | None = None
+    early_stop_patience: int | None = None
 
     @field_validator("examples", mode="before")
     @classmethod
@@ -91,6 +94,9 @@ class OptimizeRequest(BaseModel):
                     "examples": [{"input": "long text", "expected": "short"}],
                     "objectives": ["brevity", "diversity", "coverage"],
                     "target_model_id": "gpt-4o-mini",
+                    "tournament_size": 4,
+                    "recombination_rate": 0.5,
+                    "early_stop_patience": 3,
                 }
             ]
         },
@@ -131,6 +137,9 @@ class SSEEnvelope(BaseModel):
     type: Literal[
         "started",
         "progress",
+        "mutation",
+        "selected",
+        "early_stop",
         "finished",
         "failed",
         "cancelled",

--- a/innerloop/domain/judge.py
+++ b/innerloop/domain/judge.py
@@ -92,7 +92,8 @@ _tokens = 1.0
 
 
 def _norm_pair(task: str, a: str, b: str) -> tuple[str, str, str]:
-    return (task or "",) + tuple(sorted([a or "", b or ""]))
+    a_n, b_n = sorted([a or "", b or ""])
+    return (task or "", a_n, b_n)
 
 
 def _cache_size() -> int:

--- a/innerloop/domain/judge.py
+++ b/innerloop/domain/judge.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import json
+import time
+from functools import lru_cache
 from typing import Any, Dict, List
 
 from .engine import get_judge_provider
@@ -81,3 +84,70 @@ async def judge_scores(
             scores[obj] = max(0.0, min(10.0, val))
         rationale = data.get("rationale") or ""
         return {"scores": scores, "rationale": rationale}
+
+
+CALLS = 0
+_last = 0.0
+_tokens = 1.0
+
+
+def _norm_pair(task: str, a: str, b: str) -> tuple[str, str, str]:
+    return (task or "",) + tuple(sorted([a or "", b or ""]))
+
+
+def _cache_size() -> int:
+    s = get_settings()
+    return s.JUDGE_CACHE_SIZE if not s.USE_MODEL_STUB else 1024
+
+
+@lru_cache(maxsize=1024)
+def _stub_cache(task: str, a: str, b: str) -> Dict[str, Any]:
+    global CALLS
+    CALLS += 1
+    winner = a if len(a) >= len(b) else b
+    return {"winner": winner, "confidence": 1.0}
+
+
+async def _rate_limit() -> None:
+    global _tokens, _last
+    s = get_settings()
+    now = time.monotonic()
+    _tokens = min(1.0, _tokens + (now - _last) * (s.JUDGE_QPS_MAX / 1.0))
+    _last = now
+    if _tokens < 1.0:
+        await asyncio.sleep((1.0 - _tokens) / (s.JUDGE_QPS_MAX or 1.0))
+        _tokens = 1.0
+
+
+async def judge_pair(prompt_a: str, prompt_b: str, task: str) -> Dict[str, Any]:
+    await _rate_limit()
+    settings = get_settings()
+    key = _norm_pair(task, prompt_a, prompt_b)
+    if settings.USE_MODEL_STUB:
+        return _stub_cache(*key)
+    global CALLS
+    if key in _non_stub_cache:
+        return _non_stub_cache[key]
+    CALLS += 1
+    provider = get_judge_provider(settings)
+    prompt = f"Task: {task}\nA: {prompt_a}\nB: {prompt_b}\nWhich is better? Reply A or B"
+    raw = await provider.complete(
+        prompt,
+        model=settings.JUDGE_MODEL_ID,
+        temperature=0.0,
+        max_tokens=1,
+    )
+    winner = prompt_a if "A" in raw else prompt_b
+    res = {"winner": winner, "confidence": 1.0}
+    _non_stub_cache[key] = res
+    if len(_non_stub_cache) > _cache_size():
+        _non_stub_cache.pop(next(iter(_non_stub_cache)))
+    return res
+
+
+_non_stub_cache: Dict[tuple[str, str, str], Dict[str, Any]] = {}
+
+
+async def judge_score(prompt: str, candidate: str, examples: List[dict] | None, objectives: List[str] | None) -> float:
+    res = await judge_scores(prompt, candidate, examples, objectives)
+    return float(sum(res.get("scores", {}).values()))

--- a/innerloop/domain/mutations.py
+++ b/innerloop/domain/mutations.py
@@ -28,7 +28,7 @@ _OPERATORS = [_swap_words, _drop_word, _reverse]
 
 
 def mutate_prompt(base: str, k: int, seed: int) -> List[str]:
-    rnd = random.Random(seed)
+    rnd = random.Random(seed)  # nosec B311
     out: List[str] = []
     for i in range(k):
         op = _OPERATORS[i % len(_OPERATORS)]

--- a/innerloop/domain/mutations.py
+++ b/innerloop/domain/mutations.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+from typing import List
+import random
+
+
+def _swap_words(text: str, rnd: random.Random) -> str:
+    words = text.split()
+    if len(words) < 2:
+        return text
+    i, j = rnd.sample(range(len(words)), 2)
+    words[i], words[j] = words[j], words[i]
+    return " ".join(words)
+
+
+def _drop_word(text: str, rnd: random.Random) -> str:
+    words = text.split()
+    if not words:
+        return text
+    idx = rnd.randrange(len(words))
+    return " ".join(w for i, w in enumerate(words) if i != idx)
+
+
+def _reverse(text: str, rnd: random.Random) -> str:
+    return " ".join(reversed(text.split()))
+
+
+_OPERATORS = [_swap_words, _drop_word, _reverse]
+
+
+def mutate_prompt(base: str, k: int, seed: int) -> List[str]:
+    rnd = random.Random(seed)
+    out: List[str] = []
+    for i in range(k):
+        op = _OPERATORS[i % len(_OPERATORS)]
+        mutated = op(base, rnd)
+        if mutated and mutated not in out and mutated != base:
+            out.append(mutated)
+    return out

--- a/innerloop/domain/optimize_engine.py
+++ b/innerloop/domain/optimize_engine.py
@@ -81,7 +81,7 @@ async def rank_candidates(
             ordered = await tournament_rank(top, task, tournament_size)
             return ordered[:n]
         except Exception:
-            pass
+            return top[:n]
     return top[:n]
 
 

--- a/innerloop/domain/optimize_engine.py
+++ b/innerloop/domain/optimize_engine.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Callable, List, Sequence, TypeVar
 
-from .judge import judge_pair, judge_score
+from .judge import judge_pair
 from .recombination import recombine
 
 T = TypeVar("T")

--- a/innerloop/domain/optimize_engine.py
+++ b/innerloop/domain/optimize_engine.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import Callable, List, Sequence, TypeVar
 
+from .judge import judge_pair, judge_score
+from .recombination import recombine
+
 T = TypeVar("T")
 
 
@@ -45,9 +48,41 @@ def pareto_filter(
     return [item for item, _ in front[:n]]
 
 
-def rank_candidates(
+async def tournament_rank(cands: List[str], task: str, k: int) -> List[str]:
+    if k < 2 or len(cands) < 2:
+        return list(cands)
+    pool = list(cands)
+    while len(pool) > 1:
+        next_round: List[str] = []
+        for i in range(0, len(pool), k):
+            group = pool[i : i + k]
+            champ = group[0]
+            for challenger in group[1:]:
+                res = await judge_pair(champ, challenger, task)
+                champ = res.get("winner", champ)
+            next_round.append(champ)
+        pool = next_round
+    champion = pool[0]
+    rest = [c for c in cands if c != champion]
+    return [champion] + rest
+
+
+async def rank_candidates(
     items: List[str],
     objectives: List[Callable[[str], float]] | None,
+    task: str,
+    tournament_size: int,
     n: int = 1,
 ) -> List[str]:
-    return pareto_filter(items, n=n, objectives=objectives)
+    front = pareto_filter(items, n=n, objectives=objectives)
+    top = front[: min(len(front), max(1, tournament_size * 2))]
+    if len(top) > 1:
+        try:
+            ordered = await tournament_rank(top, task, tournament_size)
+            return ordered[:n]
+        except Exception:
+            pass
+    return top[:n]
+
+
+__all__ = ["pareto_filter", "tournament_rank", "rank_candidates", "recombine"]

--- a/innerloop/domain/recombination.py
+++ b/innerloop/domain/recombination.py
@@ -4,7 +4,7 @@ import random
 
 
 def crossover(a: str, b: str, seed: int) -> str:
-    rnd = random.Random(seed)
+    rnd = random.Random(seed)  # nosec B311
     sa, sb = a.split(), b.split()
     if not sa or not sb:
         return a or b
@@ -16,7 +16,7 @@ def crossover(a: str, b: str, seed: int) -> str:
 def recombine(pool: List[str], rate: float, seed: int) -> List[str]:
     if rate <= 0.0 or len(pool) < 2:
         return []
-    rnd = random.Random(seed)
+    rnd = random.Random(seed)  # nosec B311
     out: List[str] = []
     pairs: List[Tuple[str, str]] = []
     for _ in range(max(1, int(len(pool) * rate))):

--- a/innerloop/domain/recombination.py
+++ b/innerloop/domain/recombination.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+from typing import List, Tuple
+import random
+
+
+def crossover(a: str, b: str, seed: int) -> str:
+    rnd = random.Random(seed)
+    sa, sb = a.split(), b.split()
+    if not sa or not sb:
+        return a or b
+    cut_a, cut_b = rnd.randrange(1, len(sa)), rnd.randrange(1, len(sb))
+    child = " ".join(sa[:cut_a] + sb[cut_b:])
+    return child
+
+
+def recombine(pool: List[str], rate: float, seed: int) -> List[str]:
+    if rate <= 0.0 or len(pool) < 2:
+        return []
+    rnd = random.Random(seed)
+    out: List[str] = []
+    pairs: List[Tuple[str, str]] = []
+    for _ in range(max(1, int(len(pool) * rate))):
+        a, b = rnd.sample(pool, 2)
+        pairs.append((a, b))
+    for i, (a, b) in enumerate(pairs):
+        out.append(crossover(a, b, seed + i))
+    return out

--- a/innerloop/domain/retrieval.py
+++ b/innerloop/domain/retrieval.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+from typing import Dict, List, Any
+import math
+
+from ..settings import get_settings
+_idf: Dict[str, float] | None = None
+
+def _tokenize(text: str) -> List[str]:
+    return text.split()
+
+
+def _build_idf(examples: List[Dict[str, Any]]) -> None:
+    global _idf
+    if _idf is not None:
+        return
+    df: Dict[str, int] = {}
+    for ex in examples:
+        tokens = set(_tokenize(ex.get("input", "") + " " + ex.get("expected", "")))
+        for t in tokens:
+            df[t] = df.get(t, 0) + 1
+    total = max(1, len(examples))
+    _idf = {t: math.log(total / (1 + c)) for t, c in df.items()}
+
+
+async def retrieve(query: str, k: int, store: Any | None = None) -> List[Dict[str, Any]]:
+    k = max(0, min(k, get_settings().RETRIEVAL_MAX_EXAMPLES))
+    examples: List[Dict[str, Any]] = []
+    if store is not None:
+        try:
+            examples = await store.list_examples()
+        except Exception:
+            examples = []
+    if not examples:
+        return []
+    _build_idf(examples)
+    query_tokens = set(_tokenize(query))
+    scores: List[tuple[float, Dict[str, Any]]] = []
+    for ex in examples:
+        ex_tokens = set(_tokenize(ex.get("input", "") + " " + ex.get("expected", "")))
+        common = query_tokens & ex_tokens
+        score = sum((_idf or {}).get(tok, 0.0) for tok in common)
+        scores.append((score, ex))
+    scores.sort(key=lambda t: t[0], reverse=True)
+    top = [ex for sc, ex in scores if sc > 0.0][:k]
+    if not top:
+        return examples[:k]
+    return top

--- a/innerloop/settings.py
+++ b/innerloop/settings.py
@@ -40,6 +40,13 @@ class Settings(BaseSettings):
     JUDGE_PROVIDER: Literal["openrouter", "openai"] = "openrouter"
     JUDGE_MODEL_ID: str = "gpt-5"
     JUDGE_TIMEOUT_S: float = 15.0
+    JUDGE_CACHE_SIZE: int = 2048
+    JUDGE_QPS_MAX: float = 5.0
+    TOURNAMENT_SIZE: int = 4
+    RECOMBINATION_RATE: float = 0.5
+    EARLY_STOP_PATIENCE: int = 3
+    RETRIEVAL_MAX_EXAMPLES: int = 4
+    RETRIEVAL_MIN_LEN: int = 8
     TARGET_MODEL_DEFAULT: str = "openrouter/gpt-4o-mini"
     MAX_CANDIDATES: int = 8
     MAX_EXAMPLES_PER_JOB: int = 16
@@ -76,6 +83,11 @@ def get_settings() -> Settings:
         settings.RATE_LIMIT_PER_MIN = int(settings.RATE_LIMIT_OPTIMIZE_RPS * 60)
     if settings.RATE_LIMIT_OPTIMIZE_BURST is not None:
         settings.RATE_LIMIT_BURST = settings.RATE_LIMIT_OPTIMIZE_BURST
+    settings.TOURNAMENT_SIZE = max(2, int(settings.TOURNAMENT_SIZE))
+    settings.RECOMBINATION_RATE = min(1.0, max(0.0, settings.RECOMBINATION_RATE))
+    settings.EARLY_STOP_PATIENCE = max(1, int(settings.EARLY_STOP_PATIENCE))
+    settings.RETRIEVAL_MAX_EXAMPLES = max(0, int(settings.RETRIEVAL_MAX_EXAMPLES))
+    settings.RETRIEVAL_MIN_LEN = max(0, int(settings.RETRIEVAL_MIN_LEN))
     return settings
 
 

--- a/tests/test_judge_cache.py
+++ b/tests/test_judge_cache.py
@@ -1,0 +1,19 @@
+import importlib
+
+
+def test_judge_cache(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
+    monkeypatch.setenv("USE_MODEL_STUB", "true")
+    import innerloop.domain.judge as judge
+    importlib.reload(judge)
+    import asyncio
+
+    async def go():
+        before = judge.CALLS
+        a, b, task = "A", "B", "task"
+        await judge.judge_pair(a, b, task)
+        await judge.judge_pair(a, b, task)
+        after = judge.CALLS
+        assert after == before + 1
+
+    asyncio.run(go())

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,0 +1,22 @@
+import importlib
+from fastapi.testclient import TestClient
+
+
+def test_retrieval_influences_context(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
+    import innerloop.settings as settings
+    importlib.reload(settings)
+    import innerloop.main as main
+    importlib.reload(main)
+    with TestClient(main.app) as client:
+        r = client.post(
+            "/v1/optimize",
+            json={
+                "prompt": "classify sentiment",
+                "examples": [
+                    {"input": "I love it", "expected": "positive"},
+                    {"input": "I hate it", "expected": "negative"},
+                ],
+            },
+        )
+        assert r.status_code == 200

--- a/tests/test_store_sqlite.py
+++ b/tests/test_store_sqlite.py
@@ -42,7 +42,9 @@ def test_persistence_across_reload(monkeypatch, tmp_path, store):
                 events = []
                 for line in lines:
                     if line.startswith("event:"):
-                        events.append(line.split(":", 1)[1].strip())
+                        ev = line.split(":", 1)[1].strip()
+                        if ev not in {"mutation", "selected"}:
+                            events.append(ev)
                     if line.startswith("data:") and events and events[-1] == "finished":
                         break
             assert events == ["started", "progress", "finished"]

--- a/tests/test_tournament_and_early_stop.py
+++ b/tests/test_tournament_and_early_stop.py
@@ -1,5 +1,4 @@
 import importlib
-import asyncio
 from fastapi.testclient import TestClient
 
 

--- a/tests/test_tournament_and_early_stop.py
+++ b/tests/test_tournament_and_early_stop.py
@@ -1,0 +1,43 @@
+import importlib
+import asyncio
+from fastapi.testclient import TestClient
+
+
+def reload_env(monkeypatch, **env):
+    for k, v in env.items():
+        if v is None:
+            monkeypatch.delenv(k, raising=False)
+        else:
+            monkeypatch.setenv(k, str(v))
+    import innerloop.settings as settings
+    importlib.reload(settings)
+    import innerloop.main as main
+    importlib.reload(main)
+    return main
+
+
+def test_early_stop_and_events(monkeypatch):
+    main = reload_env(monkeypatch, OPENROUTER_API_KEY="dev", USE_MODEL_STUB="true")
+    with TestClient(main.app) as client:
+        r = client.post(
+            "/v1/optimize",
+            json={
+                "prompt": "improve me",
+                "seed": 42,
+                "tournament_size": 3,
+                "recombination_rate": 0.5,
+                "early_stop_patience": 1,
+            },
+            params={"iterations": 5},
+        )
+        job = r.json()["job_id"]
+        saw = set()
+        with client.stream("GET", f"/v1/optimize/{job}/events") as s:
+            for ln in s.iter_lines():
+                if ln.startswith("event:"):
+                    saw.add(ln.split(":", 1)[1].strip())
+                if ln.startswith("event: finished"):
+                    break
+        assert "mutation" in saw
+        assert "selected" in saw
+        # early_stop may occur, but not mandatory with seed


### PR DESCRIPTION
## Summary
- add configurable knobs for judge caching, tournament size, recombination, early stopping, and retrieval
- implement mutation/recombination pipeline with GPT-5 judge caching and rate limiting
- extend SSE and docs with new events and knobs; update client and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c1a753e748332b9764441258a97d2