### PR TITLE
Use Poetry for taste task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ docker-run:
 	docker run -p 8000:8000 gepa-next
 
 taste:
-	python tools/taste_and_smell.py
+	poetry run python tools/taste_and_smell.py
 
 taste-fast:
 	python tools/taste_and_smell.py --fast


### PR DESCRIPTION
## Summary
- run taste with `poetry run` so script uses Poetry environment

## Testing
- `make qa`
- `make taste` *(fails: The Poetry configuration is invalid: Either [project.name] or [tool.poetry.name] is required in package mode.)*

------
https://chatgpt.com/codex/tasks/task_e_689c2450c96c833294c8906cb52e2c62