### PR TITLE
PR3 — Pareto-v2 (Judge-Driven Selection), Rubric Support, and Event Propagation

### DIFF
--- a/innerloop/api/models/schemas.py
+++ b/innerloop/api/models/schemas.py
@@ -73,6 +73,7 @@ class OptimizeRequest(BaseModel):
     tournament_size: int | None = None
     recombination_rate: float | None = None
     early_stop_patience: int | None = None
+    evaluation_rubric: str | None = None
 
     @field_validator("examples", mode="before")
     @classmethod
@@ -104,6 +105,7 @@ class OptimizeRequest(BaseModel):
                     "tournament_size": 4,
                     "recombination_rate": 0.5,
                     "early_stop_patience": 3,
+                    "evaluation_rubric": "clarity, brevity, imagery",
                 }
             ]
         },

--- a/innerloop/settings.py
+++ b/innerloop/settings.py
@@ -44,6 +44,9 @@ class Settings(BaseSettings):
     JUDGE_TIMEOUT_S: float = 15.0
     JUDGE_CACHE_SIZE: int = 2048
     JUDGE_QPS_MAX: float = 5.0
+    ENABLE_PARETO_V2: bool = True
+    PARETO_TOPN: int = 1
+    EVALUATION_RUBRIC_DEFAULT: str = "overall quality and clarity"
     TOURNAMENT_SIZE: int = 4
     RECOMBINATION_RATE: float = 0.5
     EARLY_STOP_PATIENCE: int = 3

--- a/tests/test_pareto_v2.py
+++ b/tests/test_pareto_v2.py
@@ -1,0 +1,61 @@
+import importlib
+import asyncio
+import importlib
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def test_judge_based_selection(monkeypatch):
+    monkeypatch.setenv("USE_JUDGE_STUB", "true")
+    monkeypatch.setenv("ENABLE_PARETO_V2", "true")
+    import innerloop.settings as settings
+    importlib.reload(settings)
+    import innerloop.domain.optimize_engine as oe
+    importlib.reload(oe)
+    proposals = ["longer proposal here", "short"]
+    best = asyncio.run(
+        oe.pareto_v2(prompt="choose", proposals=proposals, n=1, rubric="brevity")
+    )
+    assert best == ["short"]
+
+
+@pytest.mark.timeout(5)
+def test_rubric_and_target_propagation_in_stream(monkeypatch):
+    monkeypatch.setenv("USE_JUDGE_STUB", "true")
+    monkeypatch.setenv("ENABLE_PARETO_V2", "true")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
+    monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
+    import innerloop.settings as settings
+    importlib.reload(settings)
+    import innerloop.api.models as api_models
+    importlib.reload(api_models)
+    import innerloop.main as main
+    importlib.reload(main)
+    with TestClient(main.app) as client:
+        r = client.post(
+            "/v1/optimize?iterations=1",
+            json={"prompt": "p", "target_model": "m", "evaluation_rubric": "r"},
+        )
+        job_id = r.json()["job_id"]
+        saw = {"rubric": False, "target": False}
+        with client.stream(
+            "GET",
+            f"/v1/optimize/{job_id}/events",
+            headers={"Authorization": "Bearer token"},
+        ) as s:
+            it = s.iter_lines()
+            next(it)
+            for line in it:
+                if line.startswith("data:"):
+                    payload = json.loads(line.split(":", 1)[1])
+                    if payload["type"] == "progress":
+                        data = payload["data"]
+                        if data.get("rubric") == "r":
+                            saw["rubric"] = True
+                        if data.get("target_model") == "m":
+                            saw["target"] = True
+                if line.startswith("event: finished"):
+                    break
+        assert all(saw.values())


### PR DESCRIPTION
## Summary
- introduce `pareto_v2` judge-driven selection with fallback to deterministic filter
- accept and surface `evaluation_rubric` in optimize requests and events
- expose configuration flags for Pareto-v2 and rubric defaults

## Testing
- `pytest -q -k "pareto_v2 or target_model" --maxfail=1`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c9d134b84833284148676f02c7703