### PR TITLE
perf: tighten SSE serialization and provider resources

### DIFF
--- a/PERFORMANCE_CHECKLIST.md
+++ b/PERFORMANCE_CHECKLIST.md
@@ -58,8 +58,7 @@ Stable streams reduce reconnects and ensure timely delivery.
 
 ## 4. Serialization & Payloads
 **Checklist**
-- Use compact JSON (`separators=(',', ':')`).
-- Consider `orjson` for heavy workloads (optional).
+- Use compact JSON (`separators=(',', ':')`); SSE falls back to `orjson` when installed for faster dumps.
 
 **Why it matters**
 Smaller payloads mean less bandwidth and CPU.
@@ -73,6 +72,7 @@ Smaller payloads mean less bandwidth and CPU.
 - Jobs stored in registry with TTLs (`JOB_TTL_*`).
 - Keep job objects lean; avoid storing large payloads.
 - Periodic reaper removes old jobs.
+- OpenRouter provider pools a single `httpx.AsyncClient` with connection limits/timeouts.
 
 **Why it matters**
 Prevents memory leaks and keeps steady-state footprint predictable.

--- a/SECURITY_CHECKLIST.md
+++ b/SECURITY_CHECKLIST.md
@@ -87,6 +87,8 @@ Mitigates burst traffic and unbounded memory growth.
 - TLS terminates at the proxy; internal app speaks HTTP.
 - SSE responses set `Cache-Control: no-store`, `Connection: keep-alive`, `X-Accel-Buffering: no`.
 - Non-SSE routes set `X-Content-Type-Options: nosniff` (consider CSP/CSRF docs for API-only service).
+- SQLite connections enable WAL and `busy_timeout=5000` to reduce lock contention.
+- Outbound OpenRouter client enforces connection limits and strict timeouts.
 
 **Why it matters**
 Protects data in transit and prevents caching or MIME sniffing issues.

--- a/innerloop/api/jobs/store.py
+++ b/innerloop/api/jobs/store.py
@@ -132,6 +132,7 @@ class SQLiteJobStore:
             raise RuntimeError("aiosqlite is required for SQLiteJobStore")
         db = await aiosqlite.connect(path)
         await db.execute("PRAGMA journal_mode=WAL")
+        await db.execute("PRAGMA busy_timeout=5000")
         await db.execute(
             """
             CREATE TABLE IF NOT EXISTS jobs (
@@ -152,6 +153,9 @@ class SQLiteJobStore:
                 PRIMARY KEY(job_id, id)
             )
             """
+        )
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_events_job_id_id ON events(job_id, id)"
         )
         await db.execute(
             """

--- a/innerloop/api/routers/optimize.py
+++ b/innerloop/api/routers/optimize.py
@@ -34,6 +34,13 @@ async def create_optimize_job(
     body: OptimizeRequest,
     iterations: int = 1,
 ) -> OptimizeResponse:
+    if iterations < 1:
+        return error_response(
+            ErrorCode.validation_error,
+            "iterations must be >= 1",
+            422,
+            request_id=request.state.request_id,
+        )
     registry: JobRegistry = request.app.state.registry
     idem_key = request.headers.get("Idempotency-Key")
     job, created = await registry.create_job(

--- a/innerloop/main.py
+++ b/innerloop/main.py
@@ -22,7 +22,7 @@ from .api.routers.eval import router as eval_router
 from .api.jobs.registry import JobRegistry
 from .api.jobs.store import JobStore, MemoryJobStore, SQLiteJobStore
 from .api.models import ErrorCode, error_response
-from .domain.engine import close_all_providers
+from .domain.engine import close_provider
 
 
 @asynccontextmanager
@@ -42,12 +42,10 @@ async def lifespan(app: FastAPI):
     finally:
         registry.shutdown()
         await store.close()
+        await close_provider()
         reaper_task.cancel()
         with suppress(Exception, asyncio.CancelledError):
             await reaper_task
-        # Close any cached external provider clients (if used)
-        with suppress(Exception):
-            await close_all_providers()
 
 
 def create_app() -> FastAPI:

--- a/tests/test_perf_json.py
+++ b/tests/test_perf_json.py
@@ -1,0 +1,6 @@
+from innerloop.api.sse import format_sse
+
+def test_format_sse_compact_json():
+    env = {"id": 1, "job_id": "j", "ts": 0.0, "data": {"x": 1}}
+    text = format_sse("progress", env)
+    assert "data: {" in text and '":1' in text

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -48,7 +48,7 @@ def test_pareto_invariants(items: List[str], n: int) -> None:
 
 
 @hsettings(max_examples=20, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
-@given(st.integers(min_value=0, max_value=3))
+@given(st.integers(min_value=1, max_value=3))
 def test_sse_invariants(monkeypatch, iterations: int) -> None:
     # auth bypass for /optimize
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")

--- a/tests/test_provider_lifecycle.py
+++ b/tests/test_provider_lifecycle.py
@@ -1,0 +1,26 @@
+import importlib, asyncio
+from innerloop.domain import engine as eng
+
+
+def test_provider_singleton(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
+    monkeypatch.setenv("USE_MODEL_STUB", "false")
+    import innerloop.settings as settings
+    importlib.reload(settings)
+    importlib.reload(eng)
+    p1 = eng.get_provider_from_env()
+    p2 = eng.get_provider_from_env()
+    assert p1 is p2
+
+
+def test_provider_close(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
+    monkeypatch.setenv("USE_MODEL_STUB", "false")
+    import innerloop.settings as settings
+    importlib.reload(settings)
+    from innerloop.domain import engine as eng
+    p = eng.get_provider_from_env()
+    assert p is eng.get_provider_from_env()
+    asyncio.run(eng.close_provider())
+    p2 = eng.get_provider_from_env()
+    assert p2 is not p

--- a/tests/test_provider_lifecycle.py
+++ b/tests/test_provider_lifecycle.py
@@ -1,4 +1,6 @@
-import importlib, asyncio
+import asyncio
+import importlib
+
 from innerloop.domain import engine as eng
 
 

--- a/tests/test_rate_headers.py
+++ b/tests/test_rate_headers.py
@@ -1,0 +1,25 @@
+import importlib
+from fastapi.testclient import TestClient
+
+
+def test_retry_after_present(monkeypatch):
+    client = TestClient(_mkapp(monkeypatch))
+    with client:
+        for _ in range(5):
+            resp = client.post("/optimize", json={"prompt":"hi"})
+        last = resp
+        assert last.status_code in (200, 429)
+        if last.status_code == 429:
+            headers = {k.lower(): v for k, v in last.headers.items()}
+            assert "retry-after" in headers
+
+
+def _mkapp(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
+    monkeypatch.setenv("RATE_LIMIT_OPTIMIZE_RPS", "1")
+    monkeypatch.setenv("RATE_LIMIT_OPTIMIZE_BURST", "1")
+    import innerloop.settings as settings
+    importlib.reload(settings)
+    import innerloop.main as main
+    importlib.reload(main)
+    return main.app

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,13 @@
+import importlib
+from fastapi.testclient import TestClient
+
+def test_iterations_min(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
+    import innerloop.settings as settings
+    importlib.reload(settings)
+    import innerloop.main as main
+    importlib.reload(main)
+    with TestClient(main.app) as client:
+        r = client.post("/v1/optimize", json={"prompt":"hi"}, params={"iterations":0})
+        assert r.status_code == 422
+        assert r.json()["error"]["code"] == "validation_error"


### PR DESCRIPTION
## Summary
- use orjson for SSE payloads when available, keeping JSON compact
- pool OpenRouter httpx client with timeouts/connection limits and close on shutdown
- validate iterations >= 1 and add SQLite busy timeout/index

## Testing
- `pytest -q`

## Troubleshooting
- **Tests suddenly 401 on SSE GET:** Ensure `OPENROUTER_API_KEY` is set or provide a valid `Authorization` header.
- **Network flakiness in OpenRouter tests:** The stub is used unless `USE_MODEL_STUB="false"` and `OPENROUTER_API_KEY` is set.
- **orjson import error:** Optional dependency; falls back to `json` if missing.
- **SQLite lock timeouts:** `busy_timeout=5000` is set; reduce test concurrency or raise the timeout if issues persist.
- **Schemathesis/content-type failures:** This PR doesn't alter OpenAPI; verify headers on `/v1/metrics` and SSE routes if regressions appear.


------
https://chatgpt.com/codex/tasks/task_e_689cd35048648332b7f1a89a27c166b7