### PR TITLE
PR-C: API/ops/docs polish — metrics (text), SSE terminals, OpenAPI responses, README, pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
             echo "PROJ_DIR=." >> "$GITHUB_ENV"
           fi
           echo "Using PROJ_DIR=${PROJ_DIR:-.}"
-      
+
       - name: Show layout (debug)
         run: |
           pwd
@@ -40,6 +40,7 @@ jobs:
       - name: Install deps
         run: |
           pip install -r "$PROJ_DIR/requirements.txt"
+          pip install pre-commit
 
       - name: Install Python client
         run: pip install -e clients/python
@@ -115,6 +116,9 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}/${{ env.PROJ_DIR }}
         working-directory: ${{ env.PROJ_DIR }}
+
+      - name: Pre-commit (no-autofix)
+        run: pre-commit run --all-files
 
 
       - name: pip-audit (dependencies)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        args: [--line-length=100]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.7
+    hooks:
+      - id: ruff
+        args: [--fix]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: [--profile=black, --line-length=100]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -1,81 +1,51 @@
-# gepa-next
+# GEPA-NEXT
 
-`gepa-next` is a FastAPI microservice template optimized for GitHub Codespaces. The goal is to provide rails for building production-ready Python services with minimal friction.
+Production-lean prompt optimization service implementing GEPA-style evolution with SSE streaming, idempotent jobs, and a fixed GPT-5 judge.
 
-## Contribution guidelines
+## Endpoints
 
-We welcome contributions! To contribute:
+- POST /v1/optimize — start an optimization job
+- GET  /v1/optimize/{job_id} — job state
+- GET  /v1/optimize/{job_id}/events — SSE stream of job events
+- DELETE /v1/optimize/{job_id} — cancel
+- GET  /v1/examples / POST /v1/examples — manage example bank
+- GET  /v1/healthz — health check
+- GET  /v1/metricsz — metrics (JSON)
+- GET  /v1/metrics — metrics (text/plain)
 
-1. **Discuss first**: open an issue using the bug or feature templates to propose your change.
-2. **Create a branch**: branch off of `main` using a descriptive name such as `feat/short-description` or `fix/bug-description`. For docs or housekeeping, use `docs/` or `chore/` prefixes.
-3. **Install dependencies**: inside your Codespace run `uv sync` to install the exact locked dependencies.
-4. **Run the quality gate**: execute `make qa` to run linting (ruff), formatting checks, type checking (mypy --strict), tests with coverage and security scans. All checks must pass locally.
-5. **Keep secrets safe**: never commit secrets. Use Codespaces secrets for any sensitive values. Do not check in `.env` files with real credentials.
-6. **Open a pull request**: push your branch and open a PR. Each PR must:
-   - Pass all CI checks (lint, type check, tests with ≥80% coverage, security scans).
-   - Receive at least one approving review.
-   - Have a clear, descriptive title and summary.
+## SSE Contract
 
-Our main branch is protected: direct pushes are disabled. All changes must go through pull requests, CI must be green, and at least one review is required before merge.
+- Response Content-Type: text/event-stream
+- Server prelude includes `retry: <ms>`; idle pings are sent as a single `:` line followed by a blank line.
+- Clients may resume by sending `Last-Event-ID: <event_id>` or `?last_event_id=` query param.
+- Terminal events are one of: `finished`, `failed`, `cancelled`.
 
-For more details see [CONTRIBUTING.md](CONTRIBUTING.md), [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), [SECURITY.md](SECURITY.md), and [SUPPORT.md](SUPPORT.md).
+## Judge vs Target
 
-## Quickstart
+- **Judge**: fixed at `openai:gpt-5-judge` (configured via settings). The judge model is not overrideable via API.
+- **Target**: selected per request via `OptimizeRequest.target_model_id`. If omitted, the service uses the default target model from settings.
+- **Providers**: Judge uses OpenRouter with OpenAI pass-through; target uses the configured provider for the chosen model.
+
+## Example Session (copy-paste)
 
 ```bash
-pip install -r requirements.txt
-export OPENROUTER_API_KEY=dev
-uvicorn innerloop.main:app --reload
+# Start a job
+curl -s -H "Authorization: Bearer $API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"Summarize: …","mode":"gepa","target_model_id":"openai:gpt-4o-mini","budget":{"max_generations":2}}' \
+  http://localhost:8000/v1/optimize | tee /tmp/job.json
 
-# create a job (v1 API)
-curl -s -X POST "http://127.0.0.1:8000/v1/optimize?iterations=1" -H "Idempotency-Key: demo-1"
+JOB=$(jq -r .job_id /tmp/job.json)
 
-# stream events
-curl -N "http://127.0.0.1:8000/v1/optimize/<job_id>/events"
+# Stream events (SSE)
+curl -N -H "Authorization: Bearer $API_TOKEN" \
+  -H "Accept: text/event-stream" \
+  http://localhost:8000/v1/optimize/$JOB/events
 
-# resume a stream using Last-Event-ID
-curl -N -H "Last-Event-ID: 5" "http://127.0.0.1:8000/v1/optimize/<job_id>/events"
+# Query state
+curl -s -H "Authorization: Bearer $API_TOKEN" \
+  http://localhost:8000/v1/optimize/$JOB | jq .
+
+# Metrics (text)
+curl -s http://localhost:8000/v1/metrics | head -n 20
 ```
-
-### Python client
-
-```python
-import asyncio
-from gepa_client import GepaClient
-
-async def main():
-    async with GepaClient("http://localhost:8000", openrouter_key="dev") as client:
-        job_id = await client.create_job("hello world", idempotency_key="demo")
-        async for env in client.stream(job_id):
-            print(env.type)
-            if env.type in {"finished", "failed", "cancelled"}:
-                break
-
-asyncio.run(main())
-```
-
-### TypeScript client
-
-```ts
-import { GepaClient } from 'gepa-client';
-
-const client = new GepaClient('http://localhost:8000', { openrouterKey: 'dev' });
-const jobId = await client.createJob('hello world');
-for await (const env of client.stream(jobId)) {
-  console.log(env.type);
-  if (['finished', 'failed', 'cancelled'].includes(env.type)) break;
-}
-```
-
-## Common errors
-
-| Code | Fix |
-| --- | --- |
-| `unauthorized` | Provide a valid bearer token or set `OPENROUTER_API_KEY` |
-| `not_found` | Verify the job ID |
-| `rate_limited` | Slow down requests or increase quota |
-| `payload_too_large` | Reduce request body size |
-| `not_cancelable` | Job already finished or failed |
-| `sse_backpressure` | Consume events faster |
-| `validation_error` | Check request parameters |
-| `internal_error` | Retry or contact support |

--- a/innerloop/api/routers/eval.py
+++ b/innerloop/api/routers/eval.py
@@ -5,12 +5,20 @@ from uuid import UUID
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
-from ..models import EvalStartRequest, OptimizeResponse, ErrorResponse
+from ..models import ErrorResponse, EvalStartRequest, OptimizeResponse
 
 router = APIRouter()
 
 
-@router.post("/eval/start", response_model=OptimizeResponse, summary="Start evaluation job")
+@router.post(
+    "/eval/start",
+    response_model=OptimizeResponse,
+    summary="Start evaluation job",
+    responses={
+        401: {"description": "Unauthorized"},
+        413: {"description": "Payload too large"},
+    },
+)
 async def eval_start(request: Request, body: EvalStartRequest):
     reg = request.app.state.registry
     payload = {"__eval__": True, **body.model_dump(exclude_none=True)}

--- a/innerloop/api/routers/examples.py
+++ b/innerloop/api/routers/examples.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Request
-from ..models import ExampleIn
 import uuid
+
+from fastapi import APIRouter, Request
+
+from ..models import ExampleIn
 
 router = APIRouter()
 
 
-@router.post("/examples/bulk", response_model=dict, status_code=200)
+@router.post(
+    "/examples/bulk",
+    response_model=dict,
+    status_code=200,
+    responses={
+        401: {"description": "Unauthorized"},
+        413: {"description": "Payload too large"},
+    },
+)
 async def examples_bulk(request: Request, items: list[ExampleIn]):
     store = request.app.state.store
     payload = []

--- a/innerloop/api/routers/health.py
+++ b/innerloop/api/routers/health.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse, PlainTextResponse
 
-from ..metrics import snapshot
+from ...settings import Settings, get_settings
+from ..metrics import snapshot_metrics_json, snapshot_metrics_text
 
 router = APIRouter()
 
@@ -17,8 +19,20 @@ async def readyz() -> dict[str, str]:
     return {"status": "ready"}
 
 
-@router.get("/metricsz")
-async def metricsz(request: Request) -> dict:
-    return snapshot()
+@router.get("/metricsz", response_class=JSONResponse, tags=["ops"])
+async def metricsz(settings: Settings = Depends(get_settings)) -> dict:
+    return snapshot_metrics_json()
 
 
+@router.get(
+    "/metrics",
+    response_class=PlainTextResponse,
+    tags=["ops"],
+    responses={
+        200: {"content": {"text/plain": {}}},
+        401: {"description": "Unauthorized"},
+    },
+)
+async def metrics(settings: Settings = Depends(get_settings)) -> PlainTextResponse:
+    """Prometheus-style text exposition format."""
+    return PlainTextResponse(snapshot_metrics_text())

--- a/innerloop/api/sse.py
+++ b/innerloop/api/sse.py
@@ -14,7 +14,10 @@ except Exception:  # pragma: no cover
     def json_dumps(obj: Dict) -> str:
         return json.dumps(obj, separators=(",", ":"))
 
-SSE_TERMINALS = {"finished", "failed", "cancelled", "shutdown"}
+
+# Terminal event names used across routers and clients.
+# Keep this list stable; tests rely on it.
+SSE_TERMINALS = {"finished", "failed", "cancelled"}
 
 
 def format_sse(event_type: str, envelope: Dict) -> str:
@@ -32,4 +35,3 @@ def format_sse(event_type: str, envelope: Dict) -> str:
 
 def prelude_retry_ms(ms: int) -> bytes:
     return f"retry: {ms}\n\n".encode()
-

--- a/tests/test_metrics_text.py
+++ b/tests/test_metrics_text.py
@@ -1,0 +1,20 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def test_metrics_text_endpoint(monkeypatch):
+    import innerloop.main as main
+
+    importlib.reload(main)
+    with TestClient(main.app) as client:
+        resp = client.get("/v1/metrics")
+        assert resp.status_code == 200
+        # FastAPI includes charset; accept either exact or startswith
+        assert resp.headers["content-type"].startswith("text/plain")
+        body = resp.text
+        assert len(body) > 0
+        # Heuristic: Prometheus format often includes HELP/TYPE or metric name
+        assert any(
+            token in body.lower() for token in ["help", "type", "requests_total", "judge_stub_used"]
+        )

--- a/tests/test_sse_terminals.py
+++ b/tests/test_sse_terminals.py
@@ -1,0 +1,4 @@
+def test_sse_terminals_constant():
+    from innerloop.api.sse import SSE_TERMINALS
+
+    assert {"finished", "failed", "cancelled"}.issubset(SSE_TERMINALS)

--- a/tools/load_sse.py
+++ b/tools/load_sse.py
@@ -1,24 +1,26 @@
 import argparse
 import asyncio
+import json
+import logging
 import statistics
 import time
 from typing import List
 
 import anyio
 import httpx
-import logging
-import json
+
+from innerloop.api.sse import SSE_TERMINALS as TERMINALS
 
 log = logging.getLogger("gepa.loadtest")
 logging.basicConfig(level=logging.INFO)
-
-TERMINALS = {"finished", "failed", "cancelled", "shutdown"}
 
 
 async def run_client(base_url: str, iterations: int, stats: List[float]) -> None:
     async with httpx.AsyncClient(base_url=base_url) as client:
         start = time.perf_counter()
-        r = await client.post("/v1/optimize", json={"prompt": "hi"}, params={"iterations": iterations})
+        r = await client.post(
+            "/v1/optimize", json={"prompt": "hi"}, params={"iterations": iterations}
+        )
         job_id = r.json()["job_id"]
         async with client.stream("GET", f"/v1/optimize/{job_id}/events") as resp:
             async for line in resp.aiter_lines():


### PR DESCRIPTION
## Summary
- expose a Prometheus-style `/v1/metrics` endpoint alongside existing JSON metrics
- centralize SSE terminal events in `SSE_TERMINALS` and document stream responses
- polish README and tighten OpenAPI responses for examples and eval endpoints

## Testing
- `pre-commit run --files .github/workflows/ci.yml README.md clients/python/gepa_client/client.py innerloop/api/metrics.py innerloop/api/routers/eval.py innerloop/api/routers/examples.py innerloop/api/routers/health.py innerloop/api/routers/optimize.py innerloop/api/sse.py tests/test_properties.py tools/load_sse.py .pre-commit-config.yaml tests/test_metrics_text.py tests/test_sse_terminals.py`
- `pytest -q tests/test_metrics_text.py tests/test_sse_terminals.py`
- `make test -j4`

------
https://chatgpt.com/codex/tasks/task_e_689ceb4592988332816ad1eb9980eaea