### PR TITLE
PR-B — Judge robustness & metrics

### DIFF
--- a/innerloop/api/metrics.py
+++ b/innerloop/api/metrics.py
@@ -12,6 +12,7 @@ _counters: Dict[str, int] = {
     "sse_clients": 0,
     "rate_limited": 0,
     "oversize_rejected": 0,
+    "judge_failures": 0,
 }
 
 _hist: Dict[str, List[float]] = {}

--- a/innerloop/domain/judge_prompts.py
+++ b/innerloop/domain/judge_prompts.py
@@ -1,8 +1,16 @@
-PAIRWISE_TEMPLATE = """You are GPT-5 acting as a strict evaluation judge.
-TASK: {task}
+PAIRWISE_TEMPLATE = """You are GPT-5 acting as a deterministic evaluation judge.
+Evaluate which candidate best satisfies the task below.
+Ignore style; reward clarity, faithfulness, and specificity.
+If tied, prefer the shorter candidate.
+
+TASK:
+{task}
+
 CANDIDATE A:
 {a}
+
 CANDIDATE B:
 {b}
-Decide the better candidate strictly for the task. Respond JSON:
-{{"winner": "A"|"B", "confidence": 0..1, "justification": "<short>"}}"""
+
+Output ONLY compact JSON on one line:
+{{"winner":"A"|"B","confidence":0..1,"justification":"<≤20 words>"}}"""

--- a/tests/test_judge_fallback.py
+++ b/tests/test_judge_fallback.py
@@ -4,6 +4,13 @@ from innerloop.api import metrics
 from innerloop.domain import engine as engine_mod
 from innerloop.domain import judge as judge_mod
 
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
 
 class _FailingProvider:
     async def complete(self, *args, **kwargs):
@@ -15,7 +22,6 @@ class _BadJsonProvider:
         return "not-json"
 
 
-@pytest.mark.asyncio
 async def test_judge_fallback_on_provider_error(monkeypatch):
     monkeypatch.setattr(engine_mod, "get_judge_provider", lambda *a, **k: _FailingProvider())
     start = metrics.snapshot_metrics_json().get("judge_failures", 0)
@@ -26,7 +32,6 @@ async def test_judge_fallback_on_provider_error(monkeypatch):
     assert end == start + 1
 
 
-@pytest.mark.asyncio
 async def test_judge_fallback_on_invalid_json(monkeypatch):
     monkeypatch.setattr(engine_mod, "get_judge_provider", lambda *a, **k: _BadJsonProvider())
     start = metrics.snapshot_metrics_json().get("judge_failures", 0)

--- a/tests/test_judge_fallback.py
+++ b/tests/test_judge_fallback.py
@@ -1,0 +1,37 @@
+import pytest
+
+from innerloop.api import metrics
+from innerloop.domain import engine as engine_mod
+from innerloop.domain import judge as judge_mod
+
+
+class _FailingProvider:
+    async def complete(self, *args, **kwargs):
+        raise RuntimeError("provider down")
+
+
+class _BadJsonProvider:
+    async def complete(self, *args, **kwargs):
+        return "not-json"
+
+
+@pytest.mark.asyncio
+async def test_judge_fallback_on_provider_error(monkeypatch):
+    monkeypatch.setattr(engine_mod, "get_judge_provider", lambda *a, **k: _FailingProvider())
+    start = metrics.snapshot_metrics_json().get("judge_failures", 0)
+    res = await judge_mod.judge(task="t", a="short", b="longer content")
+    assert res["winner"] in {"A", "B"}
+    assert res["justification"] == "fallback"
+    end = metrics.snapshot_metrics_json().get("judge_failures", 0)
+    assert end == start + 1
+
+
+@pytest.mark.asyncio
+async def test_judge_fallback_on_invalid_json(monkeypatch):
+    monkeypatch.setattr(engine_mod, "get_judge_provider", lambda *a, **k: _BadJsonProvider())
+    start = metrics.snapshot_metrics_json().get("judge_failures", 0)
+    res = await judge_mod.judge(task="t", a="short", b="much longer text than a")
+    assert res["winner"] in {"A", "B"}
+    assert res["justification"] == "fallback"
+    end = metrics.snapshot_metrics_json().get("judge_failures", 0)
+    assert end == start + 1


### PR DESCRIPTION
## Summary
- Wrap provider call & JSON parse with fallback and `judge_failures` counter.
- Deterministic tie-break (shorter candidate) to ensure reproducible behavior.
- Tighten judge and role templates (JSON-only, no CoT, token caps).
- Add tests for provider error and invalid JSON paths.

## Testing
- `pre-commit run --files innerloop/domain/judge.py innerloop/api/metrics.py innerloop/domain/judge_prompts.py innerloop/domain/reflection_runner.py tests/test_judge_fallback.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d00db73dc8332b787993c2794a3a5