### PR TITLE
PR-C — Ops & Docs polish

### DIFF
--- a/PERFORMANCE_CHECKLIST.md
+++ b/PERFORMANCE_CHECKLIST.md
@@ -34,7 +34,7 @@ Optimal server flags reduce latency and prevent connection churn during long str
 ## 2. Async I/O Discipline
 **Checklist**
 - No blocking calls; use `asyncio.sleep` only for brief SSE flushes.
-- Use bounded `asyncio.Queue` (`SSE_QUEUE_MAXSIZE`) for backpressure.
+- Use bounded `asyncio.Queue` (`SSE_BUFFER_SIZE`) for backpressure.
 
 **Why it matters**
 Blocking the event loop stalls all clients; bounded queues avoid unbounded memory use.
@@ -120,7 +120,7 @@ Metrics drive capacity planning and alerting.
 ## 9. Capacity Planning
 **Checklist**
 - Estimate memory per job/client to size instances.
-- Relate concurrency to `SSE_QUEUE_MAXSIZE` and TTLs.
+- Relate concurrency to `SSE_BUFFER_SIZE` and TTLs.
 
 **Why it matters**
 Prevents overcommit and provides headroom for bursts.

--- a/SECURITY_CHECKLIST.md
+++ b/SECURITY_CHECKLIST.md
@@ -6,7 +6,7 @@
 3. Enforce per-token rate limiting on `POST /v1/optimize`.
 4. Drop requests with bodies over `MAX_REQUEST_BYTES` (~64 KB default).
 5. Clamp job iterations to `MAX_ITERATIONS` to avoid runaway loops.
-6. Limit SSE queue size (`SSE_QUEUE_MAXSIZE`) and fail after `SSE_BACKPRESSURE_FAIL_TIMEOUT_S`.
+6. Limit SSE queue size (`SSE_BUFFER_SIZE`) and fail after `SSE_BACKPRESSURE_FAIL_TIMEOUT_S`.
 7. Serve over TLS via a trusted proxy; set strict headers for SSE and HTTP.
 8. Disable CORS unless `CORS_ALLOWED_ORIGINS` is explicitly configured.
 9. Keep dependencies pinned and run `pip-audit` regularly.
@@ -73,7 +73,7 @@ Stops resource exhaustion and unexpected code paths.
 ## 5. Rate Limiting / DoS Resilience
 **Checklist**
 - Token bucket keyed by bearer token (or anonymous-openrouter) on `POST /v1/optimize`.
-- Bounded SSE queue (`SSE_QUEUE_MAXSIZE`).
+- Bounded SSE queue (`SSE_BUFFER_SIZE`).
 
 **Why it matters**
 Mitigates burst traffic and unbounded memory growth.

--- a/USAGE.md
+++ b/USAGE.md
@@ -141,7 +141,7 @@ Examples CRUD
 - `DELETE /v1/examples/{id}` – remove an example
 
 Evaluation jobs
-- `POST /v1/eval/start` with body `{ name, target_model?, max_examples?, seed?, tournament_size?, recombination_rate?, early_stop_patience? }`
+- `POST /v1/eval/start` with body `{ name, target_model_id?, max_examples?, seed?, tournament_size?, recombination_rate?, early_stop_patience? }`
 - `GET /v1/eval/{job_id}/events` – stream `started`, `eval_started`, `eval_case`, optional `early_stop`, `eval_finished`, and terminal `finished`
 - Judge model is fixed via `JUDGE_MODEL_ID` in settings; target model may be provided per request
 
@@ -154,7 +154,7 @@ Full request with examples and objectives:
     {"input": "another"}
   ],
   "objectives": ["brevity", "diversity", "coverage"],
-  "target_model_id": "gpt-4o-mini"
+  "target_model_id": "openai:gpt-4o-mini"
 }
 ```
 
@@ -317,8 +317,7 @@ OPENROUTER_API_KEY	unset	Enables /v1/optimize POST bypass when set and no Author
 CORS_ALLOWED_ORIGINS	[]	Enable CORS for given origins
 SSE_RETRY_MS	1500	Suggested client retry backoff
 SSE_PING_INTERVAL_S	1.0	Idle ping cadence
-SSE_QUEUE_MAXSIZE	100	Per-job event queue bound
-SSE_BUFFER_SIZE	200	Ring buffer kept per job for resume
+SSE_BUFFER_SIZE	256	Per-job SSE event buffer and resume ring buffer
 SSE_BACKPRESSURE_FAIL_TIMEOUT_S	2 × ping	Fail job if .put() blocks this long
 MAX_ITERATIONS	10	Upper bound for iterations
 MAX_REQUEST_BYTES	65536	Request size cap (413 if exceeded)

--- a/innerloop/settings.py
+++ b/innerloop/settings.py
@@ -17,10 +17,10 @@ class Settings(BaseSettings):
     OPENAI_API_KEY: Optional[str] = None
     CORS_ALLOWED_ORIGINS: List[str] = Field(default_factory=list)
     SSE_RETRY_MS: int = 1500
-    SSE_QUEUE_MAXSIZE: int = 100
     SSE_PING_INTERVAL_S: float = 1.0
     SSE_BACKPRESSURE_FAIL_TIMEOUT_S: float = 2.0
-    SSE_BUFFER_SIZE: int = 200
+    # Max number of SSE events buffered per job before producers apply backpressure.
+    SSE_BUFFER_SIZE: int = 256
     MAX_ITERATIONS: int = 10
     MAX_REQUEST_BYTES: int = 64_000
     RATE_LIMIT_PER_MIN: int = 60
@@ -67,8 +67,7 @@ class Settings(BaseSettings):
     TARGET_DEFAULT_MODEL: str = "openai:gpt-4o-mini"  # default target; API may override
     COST_TRACKING_ENABLED: bool = True
     MODEL_PRICES_JSON: str = (
-        '{"openai:gpt-5-judge":{"input":0.0,"output":0.0},'
-        '"openai:gpt-4o-mini":{"input":0.0,"output":0.0}}'
+        '{"openai:gpt-5-judge":{"input":0.0,"output":0.0},"openai:gpt-4o-mini":{"input":0.0,"output":0.0}}'
     )
     EVAL_MAX_EXAMPLES: int = 100
     EVAL_MAX_CONCURRENCY: int = 8

--- a/tests/test_backpressure.py
+++ b/tests/test_backpressure.py
@@ -10,7 +10,7 @@ def test_backpressure_failure(monkeypatch):
     """Configure tiny queue + fast ping to trigger backpressure quickly"""
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
-    monkeypatch.setenv("SSE_QUEUE_MAXSIZE", "1")
+    monkeypatch.setenv("SSE_BUFFER_SIZE", "1")
     monkeypatch.setenv("SSE_PING_INTERVAL_S", "0.01")
     # Sse fail timeout defaults to 2 * ping when unset
     import innerloop.settings as settings  # type: ignore
@@ -21,9 +21,9 @@ def test_backpressure_failure(monkeypatch):
     importlib.reload(main)
     with TestClient(main.app) as client:
         headers = {"Authorization": "Bearer token"}
-        job_id = client.post(
-            "/v1/optimize", json={"prompt": "hi"}, params={"iterations": 2}, headers=headers
-        ).json()["job_id"]
+        job_id = client.post("/v1/optimize", json={"prompt": "hi"}, params={"iterations": 2}, headers=headers).json()[
+            "job_id"
+        ]
 
         # Never open the SSE stream; queue fills and job should fail
         deadline = time.time() + 3
@@ -36,4 +36,3 @@ def test_backpressure_failure(monkeypatch):
 
     assert state.get("status") == "failed"
     assert state.get("result", {}).get("error") == "sse_backpressure"
-


### PR DESCRIPTION
## Summary
- Bound per-job SSE event queue via SSE_BUFFER_SIZE to prevent unbounded memory growth.
- Document Judge vs Target behavior, SSE resume (idle pings, Last-Event-ID), and admin routes.
- Align usage examples to target_model_id.
- No API changes; operational safety improved.

## Testing
- `pre-commit run --files innerloop/api/jobs/registry.py`
- `rg 'asyncio\.Queue\(' -n`
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d01d30d8483329f36df035f7ce251