### PR TITLE
PR-C — Ops & Docs polish

### DIFF
--- a/PERFORMANCE_CHECKLIST.md
+++ b/PERFORMANCE_CHECKLIST.md
@@ -34,7 +34,7 @@ Optimal server flags reduce latency and prevent connection churn during long str
 ## 2. Async I/O Discipline
 **Checklist**
 - No blocking calls; use `asyncio.sleep` only for brief SSE flushes.
-- Use bounded `asyncio.Queue` (`SSE_QUEUE_MAXSIZE`) for backpressure.
+- Use bounded `asyncio.Queue` (`SSE_BUFFER_SIZE`) for backpressure.
 
 **Why it matters**
 Blocking the event loop stalls all clients; bounded queues avoid unbounded memory use.
@@ -120,7 +120,7 @@ Metrics drive capacity planning and alerting.
 ## 9. Capacity Planning
 **Checklist**
 - Estimate memory per job/client to size instances.
-- Relate concurrency to `SSE_QUEUE_MAXSIZE` and TTLs.
+- Relate concurrency to `SSE_BUFFER_SIZE` and TTLs.
 
 **Why it matters**
 Prevents overcommit and provides headroom for bursts.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,56 @@
 # GEPA-NEXT
 
-Production-lean prompt optimization service implementing GEPA-style evolution with SSE streaming, idempotent jobs, and a fixed GPT-5 judge.
+Production-ready GEPA-style evolutionary prompt optimization service with SSE streaming, idempotent jobs, bounded buffers/backpressure, and a fixed GPT-5 judge.
+
+## Docs
+- Quickstart: docs/QUICKSTART.md
+- API Reference: docs/API.md
+- SSE Guide: docs/SSE.md
+- Auth (Bearer): docs/AUTH.md
+- Environment (.env): docs/ENV.md
 
 ## Endpoints
-
 - POST /v1/optimize — start an optimization job
-- GET  /v1/optimize/{job_id} — job state
-- GET  /v1/optimize/{job_id}/events — SSE stream of job events
+- GET /v1/optimize/{job_id} — job state
+- GET /v1/optimize/{job_id}/events — SSE stream of job events
 - DELETE /v1/optimize/{job_id} — cancel
-- GET  /v1/examples / POST /v1/examples — manage example bank
-- GET  /v1/healthz — health check
-- GET  /v1/metricsz — metrics (JSON)
-- GET  /v1/metrics — metrics (text/plain)
+- GET /v1/examples / POST /v1/examples — manage example bank
+- GET /v1/healthz — health check
+- GET /v1/readyz — readiness check
+- GET /v1/version — version info
+- GET /v1/metricsz — metrics (JSON)
+- GET /v1/metrics — metrics (text/plain)
 
-## SSE Contract
+## Admin Endpoints
+- GET /v1/admin/jobs
+- GET /v1/admin/jobs/{job_id}
+- DELETE /v1/admin/jobs/{job_id}
+- POST /v1/admin/jobs/{job_id}/cancel
 
-- Response Content-Type: text/event-stream
-- Server prelude includes `retry: <ms>`; idle pings are sent as a single `:` line followed by a blank line.
-- Clients may resume by sending `Last-Event-ID: <event_id>` or `?last_event_id=` query param.
-- Terminal events are one of: `finished`, `failed`, `cancelled`.
+## SSE Streaming & Resume
+The events endpoint is Server-Sent Events (`text/event-stream`) with:
+- Prelude `retry: <ms>` sent first.
+- Idle pings `:\n\n` when no events are pending.
+- Terminal types: `finished`, `failed`, `cancelled`.
+- Resume using the `Last-Event-ID` header or `last_event_id` query param.
+
+**Resume example:**
+```bash
+curl -N \
+  -H "Authorization: Bearer <token>" \
+  -H "Last-Event-ID: 5" \
+  "http://localhost:8000/v1/optimize/<job_id>/events"
+```
 
 ## Judge vs Target
-
-- **Judge**: fixed at `openai:gpt-5-judge` (configured via settings). The judge model is not overrideable via API.
-- **Target**: selected per request via `OptimizeRequest.target_model_id`. If omitted, the service uses the default target model from settings.
-- **Providers**: Judge uses OpenRouter with OpenAI pass-through; target uses the configured provider for the chosen model.
+**Judge (fixed):** Hard-locked to `openai:gpt-5-judge` via settings; cannot be overridden via API.
+**Target (per-call):** Select with `target_model_id` in the request. If omitted, server uses `TARGET_MODEL_DEFAULT`.
+Providers are chosen per model; the judge runs via OpenRouter with OpenAI pass-through headers.
 
 ## Example Session (copy-paste)
-
 ```bash
 # Start a job
-curl -s -H "Authorization: Bearer $API_TOKEN" \
+curl -s -H "Authorization: Bearer $API_BEARER_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"prompt":"Summarize: …","mode":"gepa","target_model_id":"openai:gpt-4o-mini","budget":{"max_generations":2}}' \
   http://localhost:8000/v1/optimize | tee /tmp/job.json
@@ -38,14 +58,24 @@ curl -s -H "Authorization: Bearer $API_TOKEN" \
 JOB=$(jq -r .job_id /tmp/job.json)
 
 # Stream events (SSE)
-curl -N -H "Authorization: Bearer $API_TOKEN" \
+curl -N -H "Authorization: Bearer $API_BEARER_TOKEN" \
   -H "Accept: text/event-stream" \
   http://localhost:8000/v1/optimize/$JOB/events
 
 # Query state
-curl -s -H "Authorization: Bearer $API_TOKEN" \
+curl -s -H "Authorization: Bearer $API_BEARER_TOKEN" \
   http://localhost:8000/v1/optimize/$JOB | jq .
 
 # Metrics (text)
 curl -s http://localhost:8000/v1/metrics | head -n 20
 ```
+
+## Highlights
+- GPT-5 judge locked; target selectable per request.
+- Idempotent job creation; SSE streaming with resume; bounded buffers/backpressure.
+- Health/metrics/version endpoints for ops.
+
+## Contributing
+1. `pip install -e .[dev]`
+2. `pytest -q`
+3. Submit PRs with green tests.

--- a/SECURITY_CHECKLIST.md
+++ b/SECURITY_CHECKLIST.md
@@ -6,7 +6,7 @@
 3. Enforce per-token rate limiting on `POST /v1/optimize`.
 4. Drop requests with bodies over `MAX_REQUEST_BYTES` (~64 KB default).
 5. Clamp job iterations to `MAX_ITERATIONS` to avoid runaway loops.
-6. Limit SSE queue size (`SSE_QUEUE_MAXSIZE`) and fail after `SSE_BACKPRESSURE_FAIL_TIMEOUT_S`.
+6. Limit SSE queue size (`SSE_BUFFER_SIZE`) and fail after `SSE_BACKPRESSURE_FAIL_TIMEOUT_S`.
 7. Serve over TLS via a trusted proxy; set strict headers for SSE and HTTP.
 8. Disable CORS unless `CORS_ALLOWED_ORIGINS` is explicitly configured.
 9. Keep dependencies pinned and run `pip-audit` regularly.
@@ -73,7 +73,7 @@ Stops resource exhaustion and unexpected code paths.
 ## 5. Rate Limiting / DoS Resilience
 **Checklist**
 - Token bucket keyed by bearer token (or anonymous-openrouter) on `POST /v1/optimize`.
-- Bounded SSE queue (`SSE_QUEUE_MAXSIZE`).
+- Bounded SSE queue (`SSE_BUFFER_SIZE`).
 
 **Why it matters**
 Mitigates burst traffic and unbounded memory growth.

--- a/USAGE.md
+++ b/USAGE.md
@@ -141,7 +141,7 @@ Examples CRUD
 - `DELETE /v1/examples/{id}` – remove an example
 
 Evaluation jobs
-- `POST /v1/eval/start` with body `{ name, target_model?, max_examples?, seed?, tournament_size?, recombination_rate?, early_stop_patience? }`
+- `POST /v1/eval/start` with body `{ name, target_model_id?, max_examples?, seed?, tournament_size?, recombination_rate?, early_stop_patience? }`
 - `GET /v1/eval/{job_id}/events` – stream `started`, `eval_started`, `eval_case`, optional `early_stop`, `eval_finished`, and terminal `finished`
 - Judge model is fixed via `JUDGE_MODEL_ID` in settings; target model may be provided per request
 
@@ -154,7 +154,7 @@ Full request with examples and objectives:
     {"input": "another"}
   ],
   "objectives": ["brevity", "diversity", "coverage"],
-  "target_model_id": "gpt-4o-mini"
+  "target_model_id": "openai:gpt-4o-mini"
 }
 ```
 
@@ -317,8 +317,7 @@ OPENROUTER_API_KEY	unset	Enables /v1/optimize POST bypass when set and no Author
 CORS_ALLOWED_ORIGINS	[]	Enable CORS for given origins
 SSE_RETRY_MS	1500	Suggested client retry backoff
 SSE_PING_INTERVAL_S	1.0	Idle ping cadence
-SSE_QUEUE_MAXSIZE	100	Per-job event queue bound
-SSE_BUFFER_SIZE	200	Ring buffer kept per job for resume
+SSE_BUFFER_SIZE	256	Per-job SSE event buffer and resume ring buffer
 SSE_BACKPRESSURE_FAIL_TIMEOUT_S	2 × ping	Fail job if .put() blocks this long
 MAX_ITERATIONS	10	Upper bound for iterations
 MAX_REQUEST_BYTES	65536	Request size cap (413 if exceeded)

--- a/innerloop/settings.py
+++ b/innerloop/settings.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from functools import lru_cache
-from typing import List, Optional, Literal
-import os
 import json
 import json as _json
+import os
+from functools import lru_cache
+from typing import List, Literal, Optional
 
-from pydantic import Field, field_validator, computed_field
+from pydantic import Field, computed_field, field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -17,10 +17,10 @@ class Settings(BaseSettings):
     OPENAI_API_KEY: Optional[str] = None
     CORS_ALLOWED_ORIGINS: List[str] = Field(default_factory=list)
     SSE_RETRY_MS: int = 1500
-    SSE_QUEUE_MAXSIZE: int = 100
     SSE_PING_INTERVAL_S: float = 1.0
     SSE_BACKPRESSURE_FAIL_TIMEOUT_S: float = 2.0
-    SSE_BUFFER_SIZE: int = 200
+    # Max number of SSE events buffered per job before producers apply backpressure.
+    SSE_BUFFER_SIZE: int = 256
     MAX_ITERATIONS: int = 10
     MAX_REQUEST_BYTES: int = 64_000
     RATE_LIMIT_PER_MIN: int = 60
@@ -67,8 +67,7 @@ class Settings(BaseSettings):
     TARGET_DEFAULT_MODEL: str = "openai:gpt-4o-mini"  # default target; API may override
     COST_TRACKING_ENABLED: bool = True
     MODEL_PRICES_JSON: str = (
-        '{"openai:gpt-5-judge":{"input":0.0,"output":0.0},'
-        '"openai:gpt-4o-mini":{"input":0.0,"output":0.0}}'
+        '{"openai:gpt-5-judge":{"input":0.0,"output":0.0},"openai:gpt-4o-mini":{"input":0.0,"output":0.0}}'
     )
     EVAL_MAX_EXAMPLES: int = 100
     EVAL_MAX_CONCURRENCY: int = 8

--- a/tests/test_backpressure.py
+++ b/tests/test_backpressure.py
@@ -10,7 +10,7 @@ def test_backpressure_failure(monkeypatch):
     """Configure tiny queue + fast ping to trigger backpressure quickly"""
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
-    monkeypatch.setenv("SSE_QUEUE_MAXSIZE", "1")
+    monkeypatch.setenv("SSE_BUFFER_SIZE", "1")
     monkeypatch.setenv("SSE_PING_INTERVAL_S", "0.01")
     # Sse fail timeout defaults to 2 * ping when unset
     import innerloop.settings as settings  # type: ignore
@@ -21,9 +21,9 @@ def test_backpressure_failure(monkeypatch):
     importlib.reload(main)
     with TestClient(main.app) as client:
         headers = {"Authorization": "Bearer token"}
-        job_id = client.post(
-            "/v1/optimize", json={"prompt": "hi"}, params={"iterations": 2}, headers=headers
-        ).json()["job_id"]
+        job_id = client.post("/v1/optimize", json={"prompt": "hi"}, params={"iterations": 2}, headers=headers).json()[
+            "job_id"
+        ]
 
         # Never open the SSE stream; queue fills and job should fail
         deadline = time.time() + 3
@@ -36,4 +36,3 @@ def test_backpressure_failure(monkeypatch):
 
     assert state.get("status") == "failed"
     assert state.get("result", {}).get("error") == "sse_backpressure"
-


### PR DESCRIPTION
## Summary
- Bound per-job SSE event queue via SSE_BUFFER_SIZE to prevent unbounded memory growth.
- Document Judge vs Target behavior, SSE resume (idle pings, Last-Event-ID), and admin routes.
- Align usage examples to target_model_id.
- No API changes; operational safety improved.

## Testing
- `pre-commit run --files README.md USAGE.md innerloop/api/jobs/registry.py innerloop/settings.py tests/test_backpressure.py tests/test_nemesis.py PERFORMANCE_CHECKLIST.md SECURITY_CHECKLIST.md`
- `rg 'asyncio\.Queue\(' -n`
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d01d30d8483329f36df035f7ce251