### PR TITLE
feat: integrate judge into GEPA loop and thread target model

### DIFF
--- a/innerloop/domain/gepa_loop.py
+++ b/innerloop/domain/gepa_loop.py
@@ -8,8 +8,8 @@ from ..settings import get_settings
 from .candidate import Candidate, apply_edits
 from .engine import get_target_provider
 from .eval import evaluate_batch
-from .judge import judge_scores
 from .examples import load_pack
+from .judge import judge_scores
 from .operators import OPERATORS
 from .optimize_engine import pareto_filter
 from .reflection_multirole import update_lessons_journal

--- a/tests/test_eval_target_model.py
+++ b/tests/test_eval_target_model.py
@@ -34,6 +34,7 @@ def test_gepa_uses_request_target_model(monkeypatch):
 
     async def fake_evaluate_batch(provider, candidate_prompt, examples, settings, model=None):
         seen["model"] = model
+
         class Res:
             mean_scores = {"exact_match": 1.0}
             cost = 0.0
@@ -73,4 +74,3 @@ def test_gepa_uses_request_target_model(monkeypatch):
 
     asyncio.run(main())
     assert seen["model"] == "mistral-large"
-

--- a/tests/test_eval_target_model.py
+++ b/tests/test_eval_target_model.py
@@ -1,0 +1,76 @@
+import asyncio
+
+from innerloop.domain import eval as deval
+from innerloop.domain import gepa_loop
+from innerloop.domain.examples import Example
+
+
+def test_evaluate_batch_threads_model():
+    seen = {"model": None}
+
+    class FakeProv:
+        async def complete(self, prompt, model=None):
+            seen["model"] = model
+            return "ok"
+
+    class Settings:
+        TARGET_MODEL_DEFAULT = "default"
+
+    async def main():
+        await deval.evaluate_batch(
+            FakeProv(),
+            "x",
+            [Example(id="1", input="q", output="a")],
+            Settings,
+            model="gpt-4o-mini",
+        )
+
+    asyncio.run(main())
+    assert seen["model"] == "gpt-4o-mini"
+
+
+def test_gepa_uses_request_target_model(monkeypatch):
+    seen = {"model": None}
+
+    async def fake_evaluate_batch(provider, candidate_prompt, examples, settings, model=None):
+        seen["model"] = model
+        class Res:
+            mean_scores = {"exact_match": 1.0}
+            cost = 0.0
+            latency = 0.0
+            traces = []
+
+        return Res()
+
+    monkeypatch.setattr(gepa_loop, "evaluate_batch", fake_evaluate_batch)
+
+    async def fake_run_reflection(*args, **kwargs):
+        return {}
+
+    monkeypatch.setattr(gepa_loop, "run_reflection", fake_run_reflection)
+    monkeypatch.setattr(gepa_loop, "update_lessons_journal", lambda lessons, new: lessons)
+    monkeypatch.setattr(gepa_loop, "apply_edits", lambda c, edits: c)
+    monkeypatch.setattr(gepa_loop, "OPERATORS", {"reorder_sections": lambda c, rng: c})
+    monkeypatch.setattr(gepa_loop, "pareto_filter", lambda items, objectives=None, n=1: list(items))
+
+    async def fake_judge_scores(prompt, candidate, examples, objectives):
+        return {"scores": {"overall": 8}}
+
+    monkeypatch.setattr(gepa_loop, "judge_scores", fake_judge_scores)
+
+    async def emit(job, event, data):
+        pass
+
+    payload = {
+        "prompt": "hi",
+        "dataset": {"name": "toy_qa"},
+        "budget": {"max_generations": 1},
+        "target_model": "mistral-large",
+    }
+
+    async def main():
+        await gepa_loop.gepa_loop(job=None, emit=emit, payload=payload)
+
+    asyncio.run(main())
+    assert seen["model"] == "mistral-large"
+

--- a/tests/test_gepa_loop_judge_participation.py
+++ b/tests/test_gepa_loop_judge_participation.py
@@ -51,4 +51,3 @@ def test_gepa_includes_judge_axis(monkeypatch):
 
     assert called["judge"] > 0
     assert any("judge_score" in c.meta for c in captured.get("candidates", []))
-

--- a/tests/test_gepa_loop_judge_participation.py
+++ b/tests/test_gepa_loop_judge_participation.py
@@ -1,0 +1,54 @@
+import asyncio
+
+from innerloop.domain import gepa_loop
+
+
+def test_gepa_includes_judge_axis(monkeypatch):
+    called = {"judge": 0}
+
+    async def fake_judge_scores(prompt, candidate, examples, objectives):
+        called["judge"] += 1
+        return {"scores": {"overall": 8}}
+
+    monkeypatch.setattr(gepa_loop, "judge_scores", fake_judge_scores)
+
+    async def fake_evaluate_batch(provider, candidate_prompt, examples, settings, model=None):
+        class Res:
+            mean_scores = {"exact_match": 1.0}
+            cost = 0.0
+            latency = 0.0
+            traces = []
+
+        return Res()
+
+    monkeypatch.setattr(gepa_loop, "evaluate_batch", fake_evaluate_batch)
+
+    async def fake_run_reflection(*args, **kwargs):
+        return {}
+
+    monkeypatch.setattr(gepa_loop, "run_reflection", fake_run_reflection)
+    monkeypatch.setattr(gepa_loop, "update_lessons_journal", lambda lessons, new: lessons)
+    monkeypatch.setattr(gepa_loop, "apply_edits", lambda c, edits: c)
+    monkeypatch.setattr(gepa_loop, "OPERATORS", {"reorder_sections": lambda c, rng: c})
+
+    captured = {}
+
+    def fake_pareto_filter(items, objectives=None, n=1):
+        captured["candidates"] = list(items)
+        return list(items)
+
+    monkeypatch.setattr(gepa_loop, "pareto_filter", fake_pareto_filter)
+
+    async def emit(job, event, data):
+        pass
+
+    payload = {"prompt": "hello", "dataset": {"name": "toy_qa"}, "budget": {"max_generations": 1}}
+
+    async def main():
+        await gepa_loop.gepa_loop(job=None, emit=emit, payload=payload)
+
+    asyncio.run(main())
+
+    assert called["judge"] > 0
+    assert any("judge_score" in c.meta for c in captured.get("candidates", []))
+


### PR DESCRIPTION
## Summary
- invoke fixed judge during GEPA scoring and include its judge_score in candidate selection
- allow evaluate_batch and GEPA loop to honor per-request target_model
- add unit tests for judge participation and model threading

## Testing
- `pytest tests/test_gepa_loop_judge_participation.py tests/test_eval_target_model.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d5b25fd48833299d507ee783b630c