### PR TITLE
Enforce deterministic judging and add diversity to GEPA

### DIFF
--- a/innerloop/domain/gepa_loop.py
+++ b/innerloop/domain/gepa_loop.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import random
+import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Sequence, cast
-
-import re
 
 from ..settings import get_settings
 from .candidate import Candidate, apply_edits
@@ -55,24 +54,17 @@ async def gepa_loop(job, emit, payload: Dict[str, Any]) -> Dict[str, Any]:
     budget = Budget(**cast(Dict[str, Any], payload.get("budget", {})))
     max_gens = budget.max_generations or 1
     prompt = str(payload.get("prompt", ""))
-    population: List[Candidate] = [
-        Candidate(id="seed", sections=[prompt], examples_subset=None, meta={})
-    ]
+    population: List[Candidate] = [Candidate(id="seed", sections=[prompt], examples_subset=None, meta={})]
     lessons: List[str] = []
     frontier: List[Candidate] = []
     rollouts = 0
     best_score = None
     stagnation = 0
     for gen in range(max_gens):
-        await emit(
-            job, "generation_started", {"gen": gen, "population_size": len(population)}
-        )
+        await emit(job, "generation_started", {"gen": gen, "population_size": len(population)})
         scored: List[Candidate] = []
         target_model = payload.get("target_model")
-        examples_dicts = [
-            {"input": ex.input, "expected": ex.output, **ex.meta}
-            for ex in pack.examples
-        ]
+        examples_dicts = [{"input": ex.input, "expected": ex.output, **ex.meta} for ex in pack.examples]
         for cand in population:
             res = await evaluate_batch(
                 provider,
@@ -106,9 +98,7 @@ async def gepa_loop(job, emit, payload: Dict[str, Any]) -> Dict[str, Any]:
                     objectives=None,
                 )
                 vals = list((jres.get("scores") or {}).values())
-                cand.meta["judge_score"] = (
-                    sum(vals) / (10.0 * len(vals)) if vals else 0.0
-                )
+                cand.meta["judge_score"] = sum(vals) / (10.0 * len(vals)) if vals else 0.0
             except Exception:
                 cand.meta["judge_score"] = 0.0
             await emit(
@@ -170,10 +160,7 @@ async def gepa_loop(job, emit, payload: Dict[str, Any]) -> Dict[str, Any]:
         await emit(job, "reflection_started", {"gen": gen})
 
         # Build a plain dict view of examples for prompts
-        ex_dicts = [
-            {"input": ex.input, "expected": ex.output, **ex.meta}
-            for ex in pack.examples
-        ]
+        ex_dicts = [{"input": ex.input, "expected": ex.output, **ex.meta} for ex in pack.examples]
         base_text = "\n".join(best.sections)
 
         # Author drafts an improved prompt
@@ -217,14 +204,10 @@ async def gepa_loop(job, emit, payload: Dict[str, Any]) -> Dict[str, Any]:
         for r in (author, reviewer, planner, revision):
             new_lessons.extend(cast(List[str], r.get("lessons", [])))
         lessons = update_lessons_journal(lessons, new_lessons)
-        await emit(
-            job, "lessons_updated", {"count": len(lessons), "sample": lessons[:3]}
-        )
+        await emit(job, "lessons_updated", {"count": len(lessons), "sample": lessons[:3]})
 
         # Apply revision edits to the best candidate to form next population seed
-        edited = apply_edits(
-            best, cast(Sequence[Dict[str, Any]], revision.get("edits", []))
-        )
+        edited = apply_edits(best, cast(Sequence[Dict[str, Any]], revision.get("edits", [])))
 
         await emit(job, "reflection_finished", {"gen": gen})
 
@@ -242,9 +225,7 @@ async def gepa_loop(job, emit, payload: Dict[str, Any]) -> Dict[str, Any]:
         if stagnation >= 2:
             break
     return {
-        "best_prompt": (
-            "\n".join(frontier[0].sections) if frontier else payload.get("prompt", "")
-        ),
+        "best_prompt": ("\n".join(frontier[0].sections) if frontier else payload.get("prompt", "")),
         "frontier": [{"id": c.id, "score": c.meta.get("score", 0.0)} for c in frontier],
         "lessons": lessons,
     }

--- a/innerloop/domain/gepa_loop.py
+++ b/innerloop/domain/gepa_loop.py
@@ -4,6 +4,8 @@ import random
 from dataclasses import dataclass
 from typing import Any, Dict, List, Sequence, cast
 
+import re
+
 from ..settings import get_settings
 from .candidate import Candidate, apply_edits
 from .engine import get_target_provider
@@ -14,6 +16,28 @@ from .operators import OPERATORS
 from .optimize_engine import pareto_filter
 from .reflection_multirole import update_lessons_journal
 from .reflection_runner import run_reflection
+
+
+def _shingles(text: str, k: int = 3) -> set[tuple[str, ...]]:
+    toks = re.findall(r"\w+", text.lower())
+    return set(tuple(toks[i : i + k]) for i in range(max(0, len(toks) - k + 1)))
+
+
+def _max_jaccard_3gram(cand_text: str, others_texts: List[str]) -> float:
+    s = _shingles(cand_text, 3)
+    if not s:
+        return 0.0
+    best = 0.0
+    for t in others_texts:
+        o = _shingles(t, 3)
+        if not o:
+            continue
+        inter = len(s & o)
+        union = len(s | o)
+        j = (inter / union) if union else 0.0
+        if j > best:
+            best = j
+    return best
 
 
 @dataclass
@@ -31,17 +55,24 @@ async def gepa_loop(job, emit, payload: Dict[str, Any]) -> Dict[str, Any]:
     budget = Budget(**cast(Dict[str, Any], payload.get("budget", {})))
     max_gens = budget.max_generations or 1
     prompt = str(payload.get("prompt", ""))
-    population: List[Candidate] = [Candidate(id="seed", sections=[prompt], examples_subset=None, meta={})]
+    population: List[Candidate] = [
+        Candidate(id="seed", sections=[prompt], examples_subset=None, meta={})
+    ]
     lessons: List[str] = []
     frontier: List[Candidate] = []
     rollouts = 0
     best_score = None
     stagnation = 0
     for gen in range(max_gens):
-        await emit(job, "generation_started", {"gen": gen, "population_size": len(population)})
+        await emit(
+            job, "generation_started", {"gen": gen, "population_size": len(population)}
+        )
         scored: List[Candidate] = []
         target_model = payload.get("target_model")
-        examples_dicts = [{"input": ex.input, "expected": ex.output, **ex.meta} for ex in pack.examples]
+        examples_dicts = [
+            {"input": ex.input, "expected": ex.output, **ex.meta}
+            for ex in pack.examples
+        ]
         for cand in population:
             res = await evaluate_batch(
                 provider,
@@ -75,20 +106,40 @@ async def gepa_loop(job, emit, payload: Dict[str, Any]) -> Dict[str, Any]:
                     objectives=None,
                 )
                 vals = list((jres.get("scores") or {}).values())
-                cand.meta["judge_score"] = sum(vals) / (10.0 * len(vals)) if vals else 0.0
+                cand.meta["judge_score"] = (
+                    sum(vals) / (10.0 * len(vals)) if vals else 0.0
+                )
             except Exception:
                 cand.meta["judge_score"] = 0.0
-            await emit(job, "judge_scored", {"id": cand.id, "judge_score": cand.meta["judge_score"]})
+            await emit(
+                job,
+                "judge_scored",
+                {"id": cand.id, "judge_score": cand.meta["judge_score"]},
+            )
             scored.append(cand)
+        all_texts = ["\n".join(c.sections) for c in scored]
+        for i, cand in enumerate(scored):
+            max_j = _max_jaccard_3gram(all_texts[i], all_texts[:i] + all_texts[i + 1 :])
+            cand.meta["diversity"] = 1.0 - max_j
         objectives = [
             lambda c: -c.meta.get("score", 0.0),
             lambda c: c.meta.get("length", 0.0),
             lambda c: c.meta.get("cost", 0.0),
             lambda c: c.meta.get("latency", 0.0),
             lambda c: -c.meta.get("judge_score", 0.0),
+            lambda c: -c.meta.get("diversity", 0.0),
         ]
-        frontier = pareto_filter(scored, objectives=objectives, n=len(scored))
-        frontier.sort(key=lambda c: c.meta.get("judge_score", 0.0), reverse=True)
+        try:
+            frontier = pareto_filter(scored, objectives=objectives, n=len(scored))
+        except Exception:
+            frontier = pareto_filter(scored, objectives=None, n=len(scored))
+        frontier.sort(
+            key=lambda c: (
+                c.meta.get("judge_score", 0.0),
+                c.meta.get("diversity", 0.0),
+            ),
+            reverse=True,
+        )
         best = frontier[0]
         await emit(
             job,
@@ -103,11 +154,26 @@ async def gepa_loop(job, emit, payload: Dict[str, Any]) -> Dict[str, Any]:
                 },
             },
         )
+        await emit(
+            job,
+            "selected",
+            {
+                "id": best.id,
+                "meta": {
+                    "judge_score": best.meta.get("judge_score"),
+                    "diversity": best.meta.get("diversity"),
+                    "score": best.meta.get("score"),
+                },
+            },
+        )
         # === Multi-role reflection sequence ===
         await emit(job, "reflection_started", {"gen": gen})
 
         # Build a plain dict view of examples for prompts
-        ex_dicts = [{"input": ex.input, "expected": ex.output, **ex.meta} for ex in pack.examples]
+        ex_dicts = [
+            {"input": ex.input, "expected": ex.output, **ex.meta}
+            for ex in pack.examples
+        ]
         base_text = "\n".join(best.sections)
 
         # Author drafts an improved prompt
@@ -151,10 +217,14 @@ async def gepa_loop(job, emit, payload: Dict[str, Any]) -> Dict[str, Any]:
         for r in (author, reviewer, planner, revision):
             new_lessons.extend(cast(List[str], r.get("lessons", [])))
         lessons = update_lessons_journal(lessons, new_lessons)
-        await emit(job, "lessons_updated", {"count": len(lessons), "sample": lessons[:3]})
+        await emit(
+            job, "lessons_updated", {"count": len(lessons), "sample": lessons[:3]}
+        )
 
         # Apply revision edits to the best candidate to form next population seed
-        edited = apply_edits(best, cast(Sequence[Dict[str, Any]], revision.get("edits", [])))
+        edited = apply_edits(
+            best, cast(Sequence[Dict[str, Any]], revision.get("edits", []))
+        )
 
         await emit(job, "reflection_finished", {"gen": gen})
 
@@ -172,7 +242,9 @@ async def gepa_loop(job, emit, payload: Dict[str, Any]) -> Dict[str, Any]:
         if stagnation >= 2:
             break
     return {
-        "best_prompt": ("\n".join(frontier[0].sections) if frontier else payload.get("prompt", "")),
+        "best_prompt": (
+            "\n".join(frontier[0].sections) if frontier else payload.get("prompt", "")
+        ),
         "frontier": [{"id": c.id, "score": c.meta.get("score", 0.0)} for c in frontier],
         "lessons": lessons,
     }

--- a/innerloop/domain/judge.py
+++ b/innerloop/domain/judge.py
@@ -29,9 +29,14 @@ def _build_judge_prompt(
         f"Candidate: {candidate}",
     ]
     if examples:
-        ex_str = "; ".join(f"input: {e.get('input')}, expected: {e.get('expected', '')}" for e in examples)
+        ex_str = "; ".join(
+            f"input: {e.get('input')}, expected: {e.get('expected', '')}"
+            for e in examples
+        )
         parts.append(f"Examples: {ex_str}.")
-        parts.append("Coverage should reflect how well candidate addresses prompt and examples.")
+        parts.append(
+            "Coverage should reflect how well candidate addresses prompt and examples."
+        )
     return "\n".join(parts)
 
 
@@ -129,7 +134,17 @@ async def judge_pair(task: str, a: str, b: str, store=None) -> Dict[str, Any]:
         provider = get_judge_provider(s)
         prompt = PAIRWISE_TEMPLATE.format(task=task, a=a, b=b)
         try:
-            out = await provider.complete(prompt, model=s.JUDGE_MODEL_ID)
+            complete_kwargs = {
+                "prompt": prompt,
+                "model": s.JUDGE_MODEL_ID,
+                "temperature": 0.0,
+                "max_tokens": 64,
+            }
+            if "seed" in getattr(
+                provider, "SUPPORTED_KWARGS", ()
+            ):  # guard for providers w/ seed
+                complete_kwargs["seed"] = 0
+            out = await provider.complete(**complete_kwargs)
         except Exception:
             inc("judge_failures")
             winner = "A" if len(a) <= len(b) else "B"
@@ -163,7 +178,12 @@ async def judge(task: str, a: str, b: str, store=None) -> Dict[str, Any]:
     return await judge_pair(task, a, b, store)
 
 
-async def judge_score(prompt: str, candidate: str, examples: List[dict] | None, objectives: List[str] | None) -> float:
+async def judge_score(
+    prompt: str,
+    candidate: str,
+    examples: List[dict] | None,
+    objectives: List[str] | None,
+) -> float:
     res = await judge_scores(prompt, candidate, examples, objectives)
     return float(sum(res.get("scores", {}).values()))
 
@@ -175,7 +195,9 @@ async def judge_score(prompt: str, candidate: str, examples: List[dict] | None, 
 class JudgeStub:
     """Deterministic, offline judge for tests and local development."""
 
-    async def score(self, *, prompt: str, proposal: str, rubric: str | None = None) -> float:
+    async def score(
+        self, *, prompt: str, proposal: str, rubric: str | None = None
+    ) -> float:
         toks = proposal.lower().split()
         uniq = len(set(toks))
         return max(0.0, 100.0 - len(proposal)) + uniq
@@ -183,7 +205,10 @@ class JudgeStub:
     async def rank(
         self, *, prompt: str, proposals: Iterable[str], rubric: str | None = None
     ) -> List[Tuple[str, float]]:
-        items = [(p, await self.score(prompt=prompt, proposal=p, rubric=rubric)) for p in proposals]
+        items = [
+            (p, await self.score(prompt=prompt, proposal=p, rubric=rubric))
+            for p in proposals
+        ]
         items.sort(key=lambda t: t[1], reverse=True)
         return items
 
@@ -204,7 +229,9 @@ class JudgeLLM:
         # Constructing the provider is side-effect free; we won't call it in stubbed CI.
         self._provider = get_judge_provider(self._settings)
 
-    async def score(self, *, prompt: str, proposal: str, rubric: str | None = None) -> float:
+    async def score(
+        self, *, prompt: str, proposal: str, rubric: str | None = None
+    ) -> float:
         # We don't have explicit objective names here; use the built-in defaults path.
         data = await judge_scores(prompt, proposal, examples=None, objectives=None)
         return float(sum(data.get("scores", {}).values()))

--- a/tests/test_gepa_diversity_objective.py
+++ b/tests/test_gepa_diversity_objective.py
@@ -9,15 +9,9 @@ def test_diversity_meta_and_selection(monkeypatch):
 
     monkeypatch.setattr(gepa_loop, "pareto_filter", fake_pareto)
 
-    cand_a = SimpleNamespace(
-        id="A", sections=["solve by step one two three"], meta={"judge_score": 1.0}
-    )
-    cand_b = SimpleNamespace(
-        id="B", sections=["solve by step one two three"], meta={"judge_score": 1.0}
-    )
-    cand_c = SimpleNamespace(
-        id="C", sections=["completely different answer path"], meta={"judge_score": 1.0}
-    )
+    cand_a = SimpleNamespace(id="A", sections=["solve by step one two three"], meta={"judge_score": 1.0})
+    cand_b = SimpleNamespace(id="B", sections=["solve by step one two three"], meta={"judge_score": 1.0})
+    cand_c = SimpleNamespace(id="C", sections=["completely different answer path"], meta={"judge_score": 1.0})
     scored = [cand_a, cand_b, cand_c]
 
     texts = ["\n".join(c.sections) for c in scored]

--- a/tests/test_gepa_diversity_objective.py
+++ b/tests/test_gepa_diversity_objective.py
@@ -1,0 +1,36 @@
+from types import SimpleNamespace
+
+from innerloop.domain import gepa_loop
+
+
+def test_diversity_meta_and_selection(monkeypatch):
+    def fake_pareto(items, objectives=None, n=None):
+        return list(items)
+
+    monkeypatch.setattr(gepa_loop, "pareto_filter", fake_pareto)
+
+    cand_a = SimpleNamespace(
+        id="A", sections=["solve by step one two three"], meta={"judge_score": 1.0}
+    )
+    cand_b = SimpleNamespace(
+        id="B", sections=["solve by step one two three"], meta={"judge_score": 1.0}
+    )
+    cand_c = SimpleNamespace(
+        id="C", sections=["completely different answer path"], meta={"judge_score": 1.0}
+    )
+    scored = [cand_a, cand_b, cand_c]
+
+    texts = ["\n".join(c.sections) for c in scored]
+    for i, c in enumerate(scored):
+        max_j = gepa_loop._max_jaccard_3gram(texts[i], texts[:i] + texts[i + 1 :])
+        c.meta["diversity"] = 1.0 - max_j
+
+    frontier = gepa_loop.pareto_filter(scored, objectives=None, n=len(scored))
+    frontier.sort(
+        key=lambda c: (
+            c.meta.get("judge_score", 0.0),
+            c.meta.get("diversity", 0.0),
+        ),
+        reverse=True,
+    )
+    assert frontier[0].id == "C"

--- a/tests/test_gepa_events_alignment.py
+++ b/tests/test_gepa_events_alignment.py
@@ -1,0 +1,49 @@
+import asyncio
+from types import SimpleNamespace
+
+from innerloop.domain import gepa_loop
+
+
+def test_gepa_emits_selected(monkeypatch):
+    events: list[tuple[str, dict]] = []
+
+    async def fake_emit(job, name, payload):
+        events.append((name, payload))
+
+    async def fake_evaluate_batch(provider, prompt, examples, settings, model=None):
+        class Res:
+            mean_scores = {"exact_match": 0.0}
+            cost = 0.0
+            latency = 0.0
+
+        return Res()
+
+    async def fake_judge_scores(prompt, candidate, examples, objectives):
+        return {"scores": {}}
+
+    async def fake_run_reflection(*args, **kwargs):
+        return {}
+
+    monkeypatch.setattr(gepa_loop, "evaluate_batch", fake_evaluate_batch)
+    monkeypatch.setattr(gepa_loop, "judge_scores", fake_judge_scores)
+    monkeypatch.setattr(gepa_loop, "run_reflection", fake_run_reflection)
+    monkeypatch.setattr(gepa_loop, "apply_edits", lambda cand, edits: cand)
+    monkeypatch.setattr(
+        gepa_loop, "OPERATORS", {"reorder_sections": lambda c, rng=None: c}
+    )
+    monkeypatch.setattr(
+        gepa_loop, "load_pack", lambda name: SimpleNamespace(examples=[])
+    )
+    monkeypatch.setattr(gepa_loop, "get_target_provider", lambda settings: None)
+
+    payload = {
+        "prompt": "p",
+        "dataset": {"name": "toy_qa"},
+        "budget": {"max_generations": 1},
+    }
+    asyncio.run(gepa_loop.gepa_loop("job", fake_emit, payload))
+
+    sel_payloads = [p for n, p in events if n == "selected"]
+    assert sel_payloads
+    meta = sel_payloads[0]["meta"]
+    assert "judge_score" in meta and "diversity" in meta and "score" in meta

--- a/tests/test_gepa_events_alignment.py
+++ b/tests/test_gepa_events_alignment.py
@@ -28,12 +28,8 @@ def test_gepa_emits_selected(monkeypatch):
     monkeypatch.setattr(gepa_loop, "judge_scores", fake_judge_scores)
     monkeypatch.setattr(gepa_loop, "run_reflection", fake_run_reflection)
     monkeypatch.setattr(gepa_loop, "apply_edits", lambda cand, edits: cand)
-    monkeypatch.setattr(
-        gepa_loop, "OPERATORS", {"reorder_sections": lambda c, rng=None: c}
-    )
-    monkeypatch.setattr(
-        gepa_loop, "load_pack", lambda name: SimpleNamespace(examples=[])
-    )
+    monkeypatch.setattr(gepa_loop, "OPERATORS", {"reorder_sections": lambda c, rng=None: c})
+    monkeypatch.setattr(gepa_loop, "load_pack", lambda name: SimpleNamespace(examples=[]))
     monkeypatch.setattr(gepa_loop, "get_target_provider", lambda settings: None)
 
     payload = {

--- a/tests/test_judge_pair_determinism.py
+++ b/tests/test_judge_pair_determinism.py
@@ -1,0 +1,31 @@
+import asyncio
+import importlib
+
+from innerloop.domain import judge as dj
+
+
+def test_judge_pair_is_deterministic(monkeypatch):
+    calls = []
+
+    class P:
+        SUPPORTED_KWARGS = ("seed",)
+
+        async def complete(self, **kw):
+            calls.append(kw)
+            return '{"winner": "A"}'
+
+    # ensure we don't use the internal model stub path
+    monkeypatch.setenv("USE_MODEL_STUB", "false")
+    import innerloop.settings as settings
+
+    importlib.reload(settings)
+
+    monkeypatch.setattr(dj, "get_judge_provider", lambda s: P())
+
+    out1 = asyncio.run(dj.judge_pair("t", "A", "B"))
+    out2 = asyncio.run(dj.judge_pair("t", "A", "B"))
+
+    assert out1 == out2
+    assert calls[0]["temperature"] == 0.0
+    assert calls[0]["max_tokens"] == 64
+    assert "seed" in calls[0]


### PR DESCRIPTION
## Summary
- Ensure pairwise judge calls are deterministic by fixing temperature, output length, and seed
- Introduce 3-gram Jaccard diversity scoring in GEPA loop and factor into selection
- Emit `selected` events in GEPA with score, judge_score, and diversity metadata

## Testing
- `pytest tests/test_judge_pair_determinism.py tests/test_gepa_diversity_objective.py tests/test_gepa_events_alignment.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689df3424bfc83329c33056443bf8dea