### PR TITLE
Add CLI entrypoint, refine auth flow, and enhance SSE handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ HOST=0.0.0.0
 
 # --- Auth (Bearer) ---
 # Single shared bearer for local/dev. Use a real auth system in production.
-API_BEARER_TOKEN=change-me
+API_BEARER_TOKENS=["change-me"]
 
 # --- Models ---
 TARGET_MODEL_DEFAULT=openai:gpt-4o-mini

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -19,10 +21,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install black isort
-      - name: Black (check only)
-        run: black . --check --diff
-      - name: isort (check only)
-        run: isort . --profile black --check-only --diff
+      - name: Determine changed Python files
+        id: diff
+        shell: bash
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.sha }}"
+          CHANGED=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" -- '*.py' || true)
+          echo "$CHANGED" | tr '\n' ' ' > changed.txt
+          echo "changed=$(cat changed.txt)" >> "$GITHUB_OUTPUT"
+          echo "Changed Python files: $(cat changed.txt || true)"
+      - name: Black (check only on changed files)
+        if: steps.diff.outputs.changed != ''
+        run: black --check --diff ${{ steps.diff.outputs.changed }}
+      - name: isort (check only on changed files)
+        if: steps.diff.outputs.changed != ''
+        run: isort --profile black --check-only --diff ${{ steps.diff.outputs.changed }}
+      - name: No Python changes — skip format checks
+        if: steps.diff.outputs.changed == ''
+        run: echo "No Python file changes in this PR; skipping format checks."
 
   format-fix:
     if: github.event_name != 'pull_request'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,53 @@
+name: Formatting
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  format-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install formatters
+        run: |
+          python -m pip install --upgrade pip
+          pip install black isort
+      - name: Black (check only)
+        run: black . --check --diff
+      - name: isort (check only)
+        run: isort . --profile black --check-only --diff
+
+  format-fix:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install formatters
+        run: |
+          python -m pip install --upgrade pip
+          pip install black isort
+      - name: Black (auto-fix)
+        run: black .
+      - name: isort (auto-fix)
+        run: isort . --profile black
+      - name: Auto-commit formatting changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "style: auto-format with black/isort"
+          commit_user_name: github-actions[bot]
+          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          branch: ${{ github.ref_name }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 24.4.2
     hooks:
       - id: black
-        args: [--line-length=120]
+        args: [--check, --diff]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.5.7
     hooks:
@@ -13,7 +13,7 @@ repos:
     rev: 5.13.2
     hooks:
       - id: isort
-        args: [--profile=black, --line-length=120]
+        args: [--profile, black, --check-only, --diff]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: setup run lint typecheck test fmt qa docker-build docker-run taste taste-fast
+.PHONY: setup run lint typecheck test fmt qa docker-build docker-run taste taste-fast format format-check
 
 setup:
 	python -m venv .venv && . .venv/bin/activate && pip install -e .[dev]
 
 run:
-	uvicorn innerloop.main:app --host 0.0.0.0 --port ${PORT:-8000} --reload
+        python -m innerloop --dev --host 0.0.0.0 --port ${PORT:-8000} --reload
 
 lint:
 	ruff check .
@@ -30,4 +30,13 @@ taste:
 	poetry run python tools/taste_and_smell.py
 
 taste-fast:
-	python tools/taste_and_smell.py --fast
+        python tools/taste_and_smell.py --fast
+
+.PHONY: format format-check
+format:
+	black .
+	isort . --profile black
+
+format-check:
+	black . --check --diff
+	isort . --profile black --check-only --diff

--- a/USAGE.md
+++ b/USAGE.md
@@ -10,7 +10,7 @@ TL;DR (golden path)
 
 # 0) run the server (dev)
 export OPENROUTER_API_KEY=dev   # enables /optimize POST bypass without Authorization
-uvicorn innerloop.main:app --reload
+python -m innerloop --dev --reload
 
 # 1) create a job (idempotent)
 curl -s -X POST "http://localhost:8000/v1/optimize?iterations=2" \

--- a/clients/python/gepa_client/__init__.py
+++ b/clients/python/gepa_client/__init__.py
@@ -1,3 +1,3 @@
-from .client import GepaClient, SSEEnvelope, JobState
+from .client import GepaClient, JobState, SSEEnvelope
 
 __all__ = ["GepaClient", "SSEEnvelope", "JobState"]

--- a/clients/python/gepa_client/client.py
+++ b/clients/python/gepa_client/client.py
@@ -83,7 +83,9 @@ class GepaClient:
         temperature: float | None = None,
         max_tokens: int | None = None,
     ) -> str:
-        headers = self._headers({"Idempotency-Key": idempotency_key} if idempotency_key else None)
+        headers = self._headers(
+            {"Idempotency-Key": idempotency_key} if idempotency_key else None
+        )
         params = {"iterations": iterations} if iterations is not None else None
         payload: Dict[str, Any] = {"prompt": prompt}
         if context is not None:
@@ -102,7 +104,9 @@ class GepaClient:
             payload["temperature"] = temperature
         if max_tokens is not None:
             payload["max_tokens"] = max_tokens
-        resp = await self._client.post("/v1/optimize", json=payload, params=params, headers=headers)
+        resp = await self._client.post(
+            "/v1/optimize", json=payload, params=params, headers=headers
+        )
         resp.raise_for_status()
         data = resp.json()
         return data["job_id"]
@@ -113,10 +117,14 @@ class GepaClient:
         return JobState(**resp.json())
 
     async def cancel(self, job_id: str) -> None:
-        resp = await self._client.delete(f"/v1/optimize/{job_id}", headers=self._headers())
+        resp = await self._client.delete(
+            f"/v1/optimize/{job_id}", headers=self._headers()
+        )
         resp.raise_for_status()
 
-    async def stream(self, job_id: str, last_event_id: int | None = None) -> AsyncIterator[SSEEnvelope]:
+    async def stream(
+        self, job_id: str, last_event_id: int | None = None
+    ) -> AsyncIterator[SSEEnvelope]:
         backoff = 0.1
         last_id = last_event_id or self._last_ids.get(job_id, 0)
         headers = self._headers({"Last-Event-ID": str(last_id)} if last_id else None)

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -1,10 +1,15 @@
 # Authentication (Bearer)
 
-Use a single shared bearer token in development:
+Use a shared bearer token in development:
 ```
-Authorization: Bearer <API_BEARER_TOKEN>
+Authorization: Bearer <token>
 ```
 
-Set `API_BEARER_TOKEN` in `.env`. Requests without a valid bearer are rejected.
+Set `API_BEARER_TOKENS` to a JSON list of tokens and send one as the bearer. Requests without a valid bearer are rejected.
+
+Example:
+```
+API_BEARER_TOKENS=["secret123","another-token"]
+```
 
 > **Planned**: Production-ready auth (OAuth/OIDC/JWT) is on the roadmap. The dev bearer is a temporary convenience.

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -9,7 +9,9 @@ cp .env.example .env
 Key vars:
 - `LOG_LEVEL` (`DEBUG|INFO|WARNING|ERROR`) – verbosity.
 - `DEBUG_LOG_CONSOLE` (`true|false`) – force console logging.
-- `API_BEARER_TOKEN` – shared dev bearer token. Send `Authorization: Bearer <token>`.
+- `API_BEARER_TOKENS` – JSON list of bearer tokens. Send `Authorization: Bearer <token>`.
+- `HOST` – interface to bind; defaults to 127.0.0.1 (loopback).
+- `PORT` – port to bind; defaults to 8000.
 - `TARGET_MODEL_DEFAULT` – default target model when request omits `target_model_id`.
 - `JUDGE_MODEL_ID` – judge identifier (fixed in code to GPT-5 judge).
 - `OPENROUTER_API_KEY` – required for judge/provider calls.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -13,12 +13,12 @@ pip install -e .[dev]
 ## 3) Configure
 ```bash
 cp .env.example .env
-${EDITOR:-vi} .env   # set OPENROUTER_API_KEY and API_BEARER_TOKEN at minimum
+${EDITOR:-vi} .env   # set OPENROUTER_API_KEY and API_BEARER_TOKENS at minimum
 ```
 
 ## 4) Run
 ```bash
-uvicorn innerloop.main:app --host 0.0.0.0 --port 8000 --reload
+python -m innerloop --dev --host 0.0.0.0 --port 8000 --reload
 ```
 
 Health:

--- a/docs/SSE.md
+++ b/docs/SSE.md
@@ -10,8 +10,21 @@ Endpoint: `GET /v1/optimize/{job_id}/events`
 ## Event envelope
 Each `data:` line is a compact JSON object with at least:
 ```json
-{"id":5,"type":"progress","ts":1712345678,"payload":{...}}
+{"id":5,"type":"progress","schema_version":1,"job_id":"123e4567","ts":1712345678,"data":{...}}
 ```
+
+## HTTP/stream headers
+The SSE endpoint sets:
+- Content-Type: text/event-stream
+- Cache-Control: no-cache
+- Connection: keep-alive
+- X-Accel-Buffering: no
+
+## Heartbeats
+Idle heartbeats are sent as `:\n\n` to keep intermediaries from closing the connection.
+
+## Resume semantics
+Clients may resume by sending `Last-Event-ID: <id>`. The server will attempt to replay from the next event id when possible and otherwise continue from the current head.
 
 ## Curl (live)
 ```bash

--- a/examples/python_quickstart.py
+++ b/examples/python_quickstart.py
@@ -1,9 +1,11 @@
 import asyncio
 import logging
+
 from gepa_client import GepaClient
 
 log = logging.getLogger("gepa.examples")
 logging.basicConfig(level=logging.INFO)
+
 
 async def main() -> None:
     async with GepaClient("http://localhost:8000", openrouter_key="dev") as client:
@@ -14,6 +16,7 @@ async def main() -> None:
             if env.type in {"finished", "failed", "cancelled"}:
                 break
         log.info("%s", last)
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/innerloop/__main__.py
+++ b/innerloop/__main__.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import argparse
+import os
+
+import uvicorn
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dev",
+        action="store_true",
+        help="Enable developer mode (auth bypass allowed).",
+    )
+    # Default to loopback to avoid accidental exposure; override via HOST env or --host.
+    parser.add_argument("--host", default=os.getenv("HOST", "127.0.0.1"))
+    parser.add_argument("--port", type=int, default=int(os.getenv("PORT", "8000")))
+    parser.add_argument(
+        "--reload",
+        action="store_true",
+        default=os.getenv("RELOAD", "false").lower() == "true",
+    )
+    args = parser.parse_args()
+    if args.dev:
+        os.environ.setdefault("REQUIRE_AUTH", "false")
+    uvicorn.run("innerloop.main:app", host=args.host, port=args.port, reload=args.reload)
+
+
+if __name__ == "__main__":
+    main()

--- a/innerloop/__main__.py
+++ b/innerloop/__main__.py
@@ -24,7 +24,9 @@ def main() -> None:
     args = parser.parse_args()
     if args.dev:
         os.environ.setdefault("REQUIRE_AUTH", "false")
-    uvicorn.run("innerloop.main:app", host=args.host, port=args.port, reload=args.reload)
+    uvicorn.run(
+        "innerloop.main:app", host=args.host, port=args.port, reload=args.reload
+    )
 
 
 if __name__ == "__main__":

--- a/innerloop/api/metrics.py
+++ b/innerloop/api/metrics.py
@@ -61,6 +61,7 @@ def snapshot_metrics_text() -> str:
     for key, value in data.items():
         if isinstance(value, (int, float)):
             lines.append(f"# HELP {key} {key}")
-            lines.append(f"# TYPE {key} counter")
+            mtype = "gauge" if key == "sse_clients" else "counter"
+            lines.append(f"# TYPE {key} {mtype}")
             lines.append(f"{key} {value}")
     return "\n".join(lines) + "\n"

--- a/innerloop/api/middleware/auth.py
+++ b/innerloop/api/middleware/auth.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from typing import Callable
 import hmac
+from typing import Callable
 import uuid
 
 from fastapi import Request, Response
@@ -12,12 +12,16 @@ from ..models import ErrorCode, error_response
 
 
 class AuthMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next: Callable[[Request], Response]) -> Response:
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Response]
+    ) -> Response:
         settings = get_settings()
         path = request.url.path
 
         request_id = getattr(
-            request.state, "request_id", request.headers.get("x-request-id") or str(uuid.uuid4())
+            request.state,
+            "request_id",
+            request.headers.get("x-request-id") or str(uuid.uuid4()),
         )
         request.state.request_id = request_id
 

--- a/innerloop/api/middleware/auth.py
+++ b/innerloop/api/middleware/auth.py
@@ -36,17 +36,17 @@ class AuthMiddleware(BaseHTTPMiddleware):
         ):
             return await call_next(request)
 
-        # Bypass ONLY for POST /optimize (and /v1/optimize) when OPENROUTER_API_KEY set and no Authorization.
-        # GET/DELETE/SSE and all other routes (incl. admin) must require bearer auth.
+        # Dev-only: allow unauthenticated POST /optimize when OPENROUTER_API_KEY is
+        # set and REQUIRE_AUTH is false. In production (REQUIRE_AUTH=true) this path
+        # must NOT bypass authentication. GET/DELETE/SSE and all other routes always
+        # require bearer auth.
         if (
-            request.method == "POST"
+            not settings.REQUIRE_AUTH
+            and request.method == "POST"
             and path in {"/optimize", "/v1/optimize"}
             and settings.OPENROUTER_API_KEY
             and "authorization" not in request.headers
         ):
-            return await call_next(request)
-
-        if not settings.REQUIRE_AUTH:
             return await call_next(request)
 
         auth_header = request.headers.get("authorization")

--- a/innerloop/api/middleware/deprecation.py
+++ b/innerloop/api/middleware/deprecation.py
@@ -17,7 +17,9 @@ class DeprecationMiddleware(BaseHTTPMiddleware):
             "/optimize": "/v1/optimize",
         }
 
-    async def dispatch(self, request: Request, call_next: Callable[[Request], Response]) -> Response:
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Response]
+    ) -> Response:
         response = await call_next(request)
         path = request.url.path
         for old, new in self._map.items():

--- a/innerloop/api/middleware/logging.py
+++ b/innerloop/api/middleware/logging.py
@@ -4,8 +4,8 @@ import logging
 import re
 import sys
 import time
-import uuid
 from typing import Callable
+import uuid
 
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -29,9 +29,13 @@ class LoggingMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self.logger = logger
         # redact any header key matching these patterns (case-insensitive)
-        self._redact_key_re = re.compile(r"(authorization|api[-_]?key|token)", re.IGNORECASE)
+        self._redact_key_re = re.compile(
+            r"(authorization|api[-_]?key|token)", re.IGNORECASE
+        )
 
-    async def dispatch(self, request: Request, call_next: Callable[[Request], Response]) -> Response:
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Response]
+    ) -> Response:
         request_id = request.headers.get("x-request-id") or str(uuid.uuid4())
         request.state.request_id = request_id
         start = time.perf_counter()
@@ -41,7 +45,9 @@ class LoggingMiddleware(BaseHTTPMiddleware):
             return response
         finally:
             duration_ms = (time.perf_counter() - start) * 1000
-            client_ip = request.headers.get("x-forwarded-for", request.client.host if request.client else "")
+            client_ip = request.headers.get(
+                "x-forwarded-for", request.client.host if request.client else ""
+            )
             client_ip = client_ip.split(",")[0].strip()
             query = request.url.query
             if len(query) > 256:

--- a/innerloop/api/middleware/ratelimit.py
+++ b/innerloop/api/middleware/ratelimit.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
 import time
-import uuid
 from typing import Callable, Dict, Tuple
+import uuid
 
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from ...settings import get_settings
-from ..models import ErrorCode, error_response
 from ..metrics import inc
+from ..models import ErrorCode, error_response
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
@@ -19,7 +19,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self._buckets: Dict[str, Tuple[float, float]] = {}
 
-    async def dispatch(self, request: Request, call_next: Callable[[Request], Response]) -> Response:
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Response]
+    ) -> Response:
         path = request.url.path
         if not (request.method == "POST" and path in {"/optimize", "/v1/optimize"}):
             return await call_next(request)
@@ -29,7 +31,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         burst = settings.RATE_LIMIT_BURST
 
         request_id = getattr(
-            request.state, "request_id", request.headers.get("x-request-id") or str(uuid.uuid4())
+            request.state,
+            "request_id",
+            request.headers.get("x-request-id") or str(uuid.uuid4()),
         )
         request.state.request_id = request_id
 

--- a/innerloop/api/middleware/ratelimit.py
+++ b/innerloop/api/middleware/ratelimit.py
@@ -38,7 +38,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         if auth.lower().startswith("bearer "):
             token = auth.split(" ", 1)[1]
         elif settings.OPENROUTER_API_KEY and "authorization" not in request.headers:
-            token = "anonymous-openrouter"  # nosec B105
+            # Isolate unauthenticated buckets per-client to avoid cross-tenant bleed.
+            client = request.client.host if request.client else "unknown"
+            token = f"anon:{client}"  # nosec B105
         else:
             token = request.client.host or ""  # fallback
 

--- a/innerloop/api/models/__init__.py
+++ b/innerloop/api/models/__init__.py
@@ -1,16 +1,16 @@
 """API models for GEPA."""
 
+from .errors import APIError, ErrorCode, ErrorResponse, error_response
 from .schemas import (
+    EvalStartRequest,
+    Example,
+    ExampleIn,
+    JobState,
+    ObjectiveSpec,
     OptimizeRequest,
     OptimizeResponse,
-    JobState,
     SSEEnvelope,
-    ExampleIn,
-    Example,
-    EvalStartRequest,
-    ObjectiveSpec,
 )
-from .errors import APIError, ErrorCode, ErrorResponse, error_response
 
 __all__ = [
     "OptimizeRequest",

--- a/innerloop/api/models/errors.py
+++ b/innerloop/api/models/errors.py
@@ -41,4 +41,6 @@ def error_response(
     hdrs = headers.copy() if headers else {}
     if request_id:
         hdrs.setdefault("X-Request-ID", request_id)
-    return JSONResponse({"error": err.model_dump()}, status_code=status_code, headers=hdrs)
+    return JSONResponse(
+        {"error": err.model_dump()}, status_code=status_code, headers=hdrs
+    )

--- a/innerloop/api/models/schemas.py
+++ b/innerloop/api/models/schemas.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal
-
-from uuid import uuid4
 from enum import Enum
-from pydantic import BaseModel, Field, field_validator, AliasChoices
+from typing import Any, Dict, List, Literal
+from uuid import uuid4
+
+from pydantic import AliasChoices, BaseModel, Field, field_validator
 
 
 class DatasetSpec(BaseModel):
@@ -115,9 +115,7 @@ class OptimizeRequest(BaseModel):
 class OptimizeResponse(BaseModel):
     job_id: str
 
-    model_config = {
-        "json_schema_extra": {"examples": [{"job_id": "123e4567"}]}
-    }
+    model_config = {"json_schema_extra": {"examples": [{"job_id": "123e4567"}]}}
 
 
 class JobState(BaseModel):

--- a/innerloop/api/routers/admin.py
+++ b/innerloop/api/routers/admin.py
@@ -35,7 +35,10 @@ async def get_job(request: Request, job_id: str) -> JobState | Response:
     record = await store.get_job(job_id)
     if not record:
         return error_response(
-            ErrorCode.not_found, "Job not found", 404, request_id=request.state.request_id
+            ErrorCode.not_found,
+            "Job not found",
+            404,
+            request_id=request.state.request_id,
         )
     return JobState(
         job_id=record["id"],
@@ -66,7 +69,10 @@ async def cancel_job(request: Request, job_id: str) -> JobState | Response:
     job = registry.jobs.get(job_id)
     if not job:
         return error_response(
-            ErrorCode.not_found, "Job not found", 404, request_id=request.state.request_id
+            ErrorCode.not_found,
+            "Job not found",
+            404,
+            request_id=request.state.request_id,
         )
     if job.status != JobStatus.RUNNING:
         return error_response(

--- a/innerloop/api/routers/optimize.py
+++ b/innerloop/api/routers/optimize.py
@@ -9,7 +9,14 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from ...settings import get_settings
 from ..jobs.registry import JobRegistry, JobStatus
 from ..metrics import inc
-from ..models import ErrorCode, ErrorResponse, JobState, OptimizeRequest, OptimizeResponse, error_response
+from ..models import (
+    ErrorCode,
+    ErrorResponse,
+    JobState,
+    OptimizeRequest,
+    OptimizeResponse,
+    error_response,
+)
 from ..sse import SSE_TERMINALS, format_sse, prelude_retry_ms
 
 router = APIRouter()
@@ -40,7 +47,9 @@ async def create_optimize_job(
         )
     registry: JobRegistry = request.app.state.registry
     idem_key = request.headers.get("Idempotency-Key")
-    job, created = await registry.create_job(iterations, body.model_dump(), idempotency_key=idem_key)
+    job, created = await registry.create_job(
+        iterations, body.model_dump(), idempotency_key=idem_key
+    )
     request.state.job_id = job.id
     if created:
         inc("jobs_created")
@@ -59,7 +68,12 @@ async def get_job(request: Request, job_id: str) -> JobState | JSONResponse:
     if job is None:
         record = await store.get_job(job_id)
         if record is None:
-            return error_response(ErrorCode.not_found, "Job not found", 404, request_id=request.state.request_id)
+            return error_response(
+                ErrorCode.not_found,
+                "Job not found",
+                404,
+                request_id=request.state.request_id,
+            )
         request.state.job_id = job_id
         return JobState(
             job_id=record["id"],
@@ -87,7 +101,12 @@ async def cancel_job_endpoint(request: Request, job_id: str):
     registry: JobRegistry = request.app.state.registry
     job = registry.jobs.get(job_id)
     if job is None:
-        return error_response(ErrorCode.not_found, "Job not found", 404, request_id=request.state.request_id)
+        return error_response(
+            ErrorCode.not_found,
+            "Job not found",
+            404,
+            request_id=request.state.request_id,
+        )
     if job.status != JobStatus.RUNNING:
         return error_response(
             ErrorCode.not_cancelable,
@@ -131,14 +150,23 @@ async def optimize_events(request: Request, job_id: str) -> StreamingResponse:
     if job is None:
         record = await store.get_job(job_id)
         if record is None:
-            return error_response(ErrorCode.not_found, "Job not found", 404, request_id=request.state.request_id)
+            return error_response(
+                ErrorCode.not_found,
+                "Job not found",
+                404,
+                request_id=request.state.request_id,
+            )
     request.state.job_id = job_id
 
     settings = get_settings()
 
     async def event_stream() -> AsyncGenerator[bytes, None]:
-        last_id_header = request.headers.get("last-event-id") or request.query_params.get("last_event_id")
-        last_id = int(last_id_header) if last_id_header and last_id_header.isdigit() else 0
+        last_id_header = request.headers.get(
+            "last-event-id"
+        ) or request.query_params.get("last_event_id")
+        last_id = (
+            int(last_id_header) if last_id_header and last_id_header.isdigit() else 0
+        )
 
         inc("sse_clients", 1)
         yield prelude_retry_ms(settings.SSE_RETRY_MS)
@@ -154,7 +182,9 @@ async def optimize_events(request: Request, job_id: str) -> StreamingResponse:
         try:
             while True:
                 try:
-                    envelope = await asyncio.wait_for(job.queue.get(), timeout=settings.SSE_PING_INTERVAL_S)
+                    envelope = await asyncio.wait_for(
+                        job.queue.get(), timeout=settings.SSE_PING_INTERVAL_S
+                    )
                     if envelope["id"] <= last_id:
                         continue
                     yield format_sse(envelope["type"], envelope).encode()
@@ -175,4 +205,6 @@ async def optimize_events(request: Request, job_id: str) -> StreamingResponse:
         "Connection": "keep-alive",
         "X-Accel-Buffering": "no",
     }
-    return StreamingResponse(event_stream(), media_type="text/event-stream", headers=headers)
+    return StreamingResponse(
+        event_stream(), media_type="text/event-stream", headers=headers
+    )

--- a/innerloop/domain/candidate.py
+++ b/innerloop/domain/candidate.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import random
 from dataclasses import dataclass, field
+import random
 from typing import Any, List, Mapping, Sequence
 
 
@@ -11,6 +11,7 @@ class Candidate:
     sections: List[str]
     examples_subset: List[int] | None = None
     meta: dict = field(default_factory=dict)
+
 
 def apply_edits(candidate: Candidate, edits: Sequence[Mapping[str, Any]]) -> Candidate:
     from .operators import OPERATORS

--- a/innerloop/domain/engine.py
+++ b/innerloop/domain/engine.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import logging
 from contextlib import suppress
+import logging
 from typing import Dict, Optional, Protocol
 
 import httpx
@@ -54,13 +54,19 @@ class OpenRouterProvider:
             model = kwargs.get("model") or settings.TARGET_MODEL_DEFAULT
             body: Dict[str, object] = {
                 "model": model,
-                "messages": (messages if messages is not None else [{"role": "user", "content": prompt}]),
+                "messages": (
+                    messages
+                    if messages is not None
+                    else [{"role": "user", "content": prompt}]
+                ),
             }
             if temperature is not None:
                 body["temperature"] = temperature
             if max_tokens is not None:
                 body["max_tokens"] = max_tokens
-            resp = await self.client.post("https://openrouter.ai/api/v1/chat/completions", json=body)
+            resp = await self.client.post(
+                "https://openrouter.ai/api/v1/chat/completions", json=body
+            )
             data = resp.json()
             return data.get("choices", [{}])[0].get("message", {}).get("content", "")
         except Exception:
@@ -87,13 +93,19 @@ class OpenAIProvider:
             model = kwargs.get("model")
             body: Dict[str, object] = {
                 "model": model,
-                "messages": (messages if messages is not None else [{"role": "user", "content": prompt}]),
+                "messages": (
+                    messages
+                    if messages is not None
+                    else [{"role": "user", "content": prompt}]
+                ),
             }
             if temperature is not None:
                 body["temperature"] = temperature
             if max_tokens is not None:
                 body["max_tokens"] = max_tokens
-            resp = await self.client.post("https://api.openai.com/v1/chat/completions", json=body)
+            resp = await self.client.post(
+                "https://api.openai.com/v1/chat/completions", json=body
+            )
             data = resp.json()
             return data.get("choices", [{}])[0].get("message", {}).get("content", "")
         except Exception:
@@ -134,7 +146,9 @@ def get_judge_provider(settings: Optional[Settings] = None) -> ModelProvider:
             if getattr(settings, "ALLOW_JUDGE_FALLBACK", False):
                 logger.warning("OpenRouter judge missing OPENAI_API_KEY; falling back")
                 return LocalEchoProvider()
-            raise RuntimeError("JUDGE_PROVIDER=openrouter requires OPENAI_API_KEY for GPT-5 judge")
+            raise RuntimeError(
+                "JUDGE_PROVIDER=openrouter requires OPENAI_API_KEY for GPT-5 judge"
+            )
         if settings.OPENROUTER_API_KEY:
             extra = {"X-OpenAI-Api-Key": settings.OPENAI_API_KEY}
             if (
@@ -151,9 +165,12 @@ def get_judge_provider(settings: Optional[Settings] = None) -> ModelProvider:
     if settings.JUDGE_PROVIDER == "openai" and settings.OPENAI_API_KEY:
         if (
             not isinstance(_judge_provider_singleton, OpenAIProvider)
-            or _judge_provider_singleton.client.headers.get("Authorization") != f"Bearer {settings.OPENAI_API_KEY}"
+            or _judge_provider_singleton.client.headers.get("Authorization")
+            != f"Bearer {settings.OPENAI_API_KEY}"
         ):
-            _judge_provider_singleton = OpenAIProvider(settings.OPENAI_API_KEY, timeout=settings.JUDGE_TIMEOUT_S)
+            _judge_provider_singleton = OpenAIProvider(
+                settings.OPENAI_API_KEY, timeout=settings.JUDGE_TIMEOUT_S
+            )
         return _judge_provider_singleton
     return LocalEchoProvider()
 

--- a/innerloop/domain/eval.py
+++ b/innerloop/domain/eval.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
 from dataclasses import dataclass
+import hashlib
 from typing import Dict, Sequence
 
 from .examples import Example

--- a/innerloop/domain/eval_runner.py
+++ b/innerloop/domain/eval_runner.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
-from typing import List, Dict
+from typing import Dict, List
+
 from ..settings import get_settings
+from .judge import judge_pair
 from .mutations import mutate_prompt
 from .optimize_engine import pareto_filter
-from .judge import judge_pair
 from .recombination import recombine
 
 
-async def run_eval(store, base_prompt: str, target_model: str | None, seed: int, limits: dict, emit):
+async def run_eval(
+    store, base_prompt: str, target_model: str | None, seed: int, limits: dict, emit
+):
     s = get_settings()
     max_ex = min(limits.get("max_examples") or s.EVAL_MAX_EXAMPLES, s.EVAL_MAX_EXAMPLES)
     examples = await store.list_examples(limit=max_ex, offset=0)

--- a/innerloop/domain/examples.py
+++ b/innerloop/domain/examples.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
+import json
 from pathlib import Path
 from typing import List
 
@@ -52,4 +52,6 @@ def load_pack(name: str) -> ExamplePack:
                 out = rec.get("output", "")
             meta = {k: v for k, v in rec.items() if k not in _EXCLUDED_KEYS}
             examples.append(Example(str(rec.get("id")), inp, out, meta))
-    return ExamplePack(name=name, metrics=pack_info.get("metrics", []), examples=examples)
+    return ExamplePack(
+        name=name, metrics=pack_info.get("metrics", []), examples=examples
+    )

--- a/innerloop/domain/judge.py
+++ b/innerloop/domain/judge.py
@@ -30,9 +30,14 @@ def _build_judge_prompt(
         f"Candidate: {candidate}",
     ]
     if examples:
-        ex_str = "; ".join(f"input: {e.get('input')}, expected: {e.get('expected', '')}" for e in examples)
+        ex_str = "; ".join(
+            f"input: {e.get('input')}, expected: {e.get('expected', '')}"
+            for e in examples
+        )
         parts.append(f"Examples: {ex_str}.")
-        parts.append("Coverage should reflect how well candidate addresses prompt and examples.")
+        parts.append(
+            "Coverage should reflect how well candidate addresses prompt and examples."
+        )
     return "\n".join(parts)
 
 
@@ -71,7 +76,9 @@ async def judge_scores(
             "temperature": 0.0,
             "max_tokens": 128,
         }
-        if "seed" in getattr(provider, "SUPPORTED_KWARGS", ()):  # providers supporting seed
+        if "seed" in getattr(
+            provider, "SUPPORTED_KWARGS", ()
+        ):  # providers supporting seed
             complete_kwargs["seed"] = 0
         try:
             raw = await provider.complete(message, **complete_kwargs)
@@ -138,7 +145,9 @@ async def judge_pair(task: str, a: str, b: str, store=None) -> Dict[str, Any]:
                 "temperature": 0.0,
                 "max_tokens": 64,
             }
-            if "seed" in getattr(provider, "SUPPORTED_KWARGS", ()):  # guard for providers w/ seed
+            if "seed" in getattr(
+                provider, "SUPPORTED_KWARGS", ()
+            ):  # guard for providers w/ seed
                 complete_kwargs["seed"] = 0
             out = await provider.complete(prompt=prompt, **complete_kwargs)
         except Exception:
@@ -191,7 +200,9 @@ async def judge_score(
 class JudgeStub:
     """Deterministic, offline judge for tests and local development."""
 
-    async def score(self, *, prompt: str, proposal: str, rubric: str | None = None) -> float:
+    async def score(
+        self, *, prompt: str, proposal: str, rubric: str | None = None
+    ) -> float:
         toks = proposal.lower().split()
         uniq = len(set(toks))
         return max(0.0, 100.0 - len(proposal)) + uniq
@@ -199,7 +210,10 @@ class JudgeStub:
     async def rank(
         self, *, prompt: str, proposals: Iterable[str], rubric: str | None = None
     ) -> List[Tuple[str, float]]:
-        items = [(p, await self.score(prompt=prompt, proposal=p, rubric=rubric)) for p in proposals]
+        items = [
+            (p, await self.score(prompt=prompt, proposal=p, rubric=rubric))
+            for p in proposals
+        ]
         items.sort(key=lambda t: t[1], reverse=True)
         return items
 
@@ -220,7 +234,9 @@ class JudgeLLM:
         # Constructing the provider is side-effect free; we won't call it in stubbed CI.
         self._provider = get_judge_provider(self._settings)
 
-    async def score(self, *, prompt: str, proposal: str, rubric: str | None = None) -> float:
+    async def score(
+        self, *, prompt: str, proposal: str, rubric: str | None = None
+    ) -> float:
         # We don't have explicit objective names here; use the built-in defaults path.
         data = await judge_scores(prompt, proposal, examples=None, objectives=None)
         return float(sum(data.get("scores", {}).values()))

--- a/innerloop/domain/mutations.py
+++ b/innerloop/domain/mutations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
-from typing import List
+
 import random
+from typing import List
 
 
 def _swap_words(text: str, rnd: random.Random) -> str:

--- a/innerloop/domain/objectives.py
+++ b/innerloop/domain/objectives.py
@@ -25,7 +25,9 @@ def score_coverage(text: str, examples: List[dict]) -> float:
     return len(example_set & text_set) / len(example_set)
 
 
-def get_objectives(names: List[str] | None, examples: List[dict] | None) -> List[Callable[[str], float]]:
+def get_objectives(
+    names: List[str] | None, examples: List[dict] | None
+) -> List[Callable[[str], float]]:
     examples = examples or []
     funcs: List[Callable[[str], float]] = []
     for name in names or []:
@@ -34,7 +36,9 @@ def get_objectives(names: List[str] | None, examples: List[dict] | None) -> List
         elif name == "diversity":
             funcs.append(score_diversity)
         elif name == "coverage":
+
             def cov_fn(text: str, _examples=examples):
                 return score_coverage(text, _examples)
+
             funcs.append(cov_fn)
     return funcs

--- a/innerloop/domain/operators.py
+++ b/innerloop/domain/operators.py
@@ -6,40 +6,75 @@ from typing import Callable, Dict
 from .candidate import Candidate
 
 
-def edit_constraints(candidate: Candidate, rng: random.Random, note: str | None = None) -> Candidate:
-    new = Candidate(candidate.id, list(candidate.sections), list(candidate.examples_subset or []), dict(candidate.meta))
+def edit_constraints(
+    candidate: Candidate, rng: random.Random, note: str | None = None
+) -> Candidate:
+    new = Candidate(
+        candidate.id,
+        list(candidate.sections),
+        list(candidate.examples_subset or []),
+        dict(candidate.meta),
+    )
     new.meta["constraints"] = note or "edited"
     return new
 
 
 def reword_objectives(candidate: Candidate, rng: random.Random) -> Candidate:
-    new = Candidate(candidate.id, list(candidate.sections), list(candidate.examples_subset or []), dict(candidate.meta))
+    new = Candidate(
+        candidate.id,
+        list(candidate.sections),
+        list(candidate.examples_subset or []),
+        dict(candidate.meta),
+    )
     new.sections = [s + "!" for s in new.sections]
     return new
 
 
 def reorder_sections(candidate: Candidate, rng: random.Random) -> Candidate:
-    new = Candidate(candidate.id, list(candidate.sections), list(candidate.examples_subset or []), dict(candidate.meta))
+    new = Candidate(
+        candidate.id,
+        list(candidate.sections),
+        list(candidate.examples_subset or []),
+        dict(candidate.meta),
+    )
     rng.shuffle(new.sections)
     return new
 
 
 def toggle_chain_of_thought(candidate: Candidate, rng: random.Random) -> Candidate:
-    new = Candidate(candidate.id, list(candidate.sections), list(candidate.examples_subset or []), dict(candidate.meta))
+    new = Candidate(
+        candidate.id,
+        list(candidate.sections),
+        list(candidate.examples_subset or []),
+        dict(candidate.meta),
+    )
     new.meta["chain_of_thought"] = not new.meta.get("chain_of_thought", False)
     return new
 
 
 def swap_examples(candidate: Candidate, rng: random.Random) -> Candidate:
-    new = Candidate(candidate.id, list(candidate.sections), list(candidate.examples_subset or []), dict(candidate.meta))
+    new = Candidate(
+        candidate.id,
+        list(candidate.sections),
+        list(candidate.examples_subset or []),
+        dict(candidate.meta),
+    )
     if new.examples_subset is not None and len(new.examples_subset) >= 2:
         i, j = 0, 1
-        new.examples_subset[i], new.examples_subset[j] = new.examples_subset[j], new.examples_subset[i]
+        new.examples_subset[i], new.examples_subset[j] = (
+            new.examples_subset[j],
+            new.examples_subset[i],
+        )
     return new
 
 
 def trim_examples(candidate: Candidate, rng: random.Random) -> Candidate:
-    new = Candidate(candidate.id, list(candidate.sections), list(candidate.examples_subset or []), dict(candidate.meta))
+    new = Candidate(
+        candidate.id,
+        list(candidate.sections),
+        list(candidate.examples_subset or []),
+        dict(candidate.meta),
+    )
     if new.examples_subset:
         new.examples_subset = new.examples_subset[:-1]
     return new

--- a/innerloop/domain/optimize_engine.py
+++ b/innerloop/domain/optimize_engine.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Callable, List, Sequence, TypeVar
 
-from .judge import judge_pair, get_judge
 from ..settings import get_settings
+from .judge import get_judge, judge_pair
 from .recombination import recombine
 
 T = TypeVar("T")

--- a/innerloop/domain/recombination.py
+++ b/innerloop/domain/recombination.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
-from typing import List, Tuple
+
 import random
+from typing import List, Tuple
 
 
 def crossover(a: str, b: str, seed: int) -> str:

--- a/innerloop/domain/reflection_multirole.py
+++ b/innerloop/domain/reflection_multirole.py
@@ -4,7 +4,9 @@ from collections import Counter
 from typing import List
 
 
-def update_lessons_journal(existing: List[str], new: List[str], max_chars: int = 2000) -> List[str]:
+def update_lessons_journal(
+    existing: List[str], new: List[str], max_chars: int = 2000
+) -> List[str]:
     freq = Counter(existing)
     freq.update(new)
     ordered = [lesson for lesson, _ in freq.most_common()]

--- a/innerloop/domain/retrieval.py
+++ b/innerloop/domain/retrieval.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
-from typing import Dict, List, Any
+
 import math
+from typing import Any, Dict, List
 
 from ..settings import get_settings
+
 _idf: Dict[str, float] | None = None
+
 
 def _tokenize(text: str) -> List[str]:
     return text.split()
@@ -22,7 +25,9 @@ def _build_idf(examples: List[Dict[str, Any]]) -> None:
     _idf = {t: math.log(total / (1 + c)) for t, c in df.items()}
 
 
-async def retrieve(query: str, k: int, store: Any | None = None) -> List[Dict[str, Any]]:
+async def retrieve(
+    query: str, k: int, store: Any | None = None
+) -> List[Dict[str, Any]]:
     k = max(0, min(k, get_settings().RETRIEVAL_MAX_EXAMPLES))
     examples: List[Dict[str, Any]] = []
     if store is not None:

--- a/innerloop/main.py
+++ b/innerloop/main.py
@@ -5,24 +5,24 @@ from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
-from .settings import get_settings
-from .api.middleware.auth import AuthMiddleware
-from .api.middleware.logging import LoggingMiddleware
-from .api.middleware.ratelimit import RateLimitMiddleware
-from .api.middleware.limits import SizeLimitMiddleware
-from .api.middleware.deprecation import DeprecationMiddleware
-from .api.routers.health import router as health_router
-from .api.routers.optimize import router as optimize_router
-from .api.routers.admin import router as admin_router
-from .api.routers.examples import router as examples_router
-from .api.routers.eval import router as eval_router
 from .api.jobs.registry import JobRegistry
 from .api.jobs.store import JobStore, MemoryJobStore, SQLiteJobStore
+from .api.middleware.auth import AuthMiddleware
+from .api.middleware.deprecation import DeprecationMiddleware
+from .api.middleware.limits import SizeLimitMiddleware
+from .api.middleware.logging import LoggingMiddleware
+from .api.middleware.ratelimit import RateLimitMiddleware
 from .api.models import ErrorCode, error_response
+from .api.routers.admin import router as admin_router
+from .api.routers.eval import router as eval_router
+from .api.routers.examples import router as examples_router
+from .api.routers.health import router as health_router
+from .api.routers.optimize import router as optimize_router
 from .domain.engine import close_provider
+from .settings import get_settings
 
 
 @asynccontextmanager
@@ -92,7 +92,9 @@ def create_app() -> FastAPI:
         )
 
     @app.exception_handler(Exception)
-    async def unhandled_handler(request: Request, exc: Exception) -> JSONResponse:  # pragma: no cover - simple
+    async def unhandled_handler(
+        request: Request, exc: Exception
+    ) -> JSONResponse:  # pragma: no cover - simple
         return error_response(
             ErrorCode.internal_error,
             "Internal server error",

--- a/innerloop/settings.py
+++ b/innerloop/settings.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from functools import lru_cache
 import json
 import json as _json
 import os
-from functools import lru_cache
 from typing import List, Literal, Optional
 
 from pydantic import Field, computed_field, field_validator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,21 @@ exclude = ["tests/"]
 [[tool.mypy.overrides]]
 module = ["innerloop.api.*"]
 ignore_errors = true
+
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+exclude = '''
+/(
+    \.git
+  | \.venv
+  | build
+  | dist
+)/
+'''
+
+[tool.isort]
+profile = "black"
+py_version = 311
+force_sort_within_sections = true
+src_paths = ["innerloop", "tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import os
-import sys
 from pathlib import Path
+import sys
 
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
+import os
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+# Default to dev-mode auth bypass in tests unless overridden.
+os.environ.setdefault("REQUIRE_AUTH", "false")

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -8,8 +8,10 @@ def create_client(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     return TestClient(main.app)
 
@@ -41,4 +43,3 @@ def test_admin_endpoints(monkeypatch):
             f"/v1/optimize/{job_id}", headers={"Authorization": "Bearer token"}
         )
         assert state_resp.status_code == 404
-

--- a/tests/test_auth_bypass.py
+++ b/tests/test_auth_bypass.py
@@ -1,4 +1,5 @@
 import importlib
+
 from fastapi.testclient import TestClient
 
 
@@ -7,8 +8,10 @@ def test_bypass_post_only(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     with TestClient(main.app) as client:
         job_id = client.post("/v1/optimize", json={"prompt": "hi"}).json()["job_id"]
@@ -20,4 +23,3 @@ def test_bypass_post_only(monkeypatch):
             f"/v1/optimize/{job_id}/events", headers={"Authorization": "Bearer token"}
         )
         assert resp2.status_code == 200
-

--- a/tests/test_auth_prod.py
+++ b/tests/test_auth_prod.py
@@ -8,8 +8,10 @@ def _mkapp(monkeypatch, require_auth: bool):
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     monkeypatch.setenv("REQUIRE_AUTH", "true" if require_auth else "false")
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     return main.app
 

--- a/tests/test_auth_prod.py
+++ b/tests/test_auth_prod.py
@@ -1,0 +1,28 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def _mkapp(monkeypatch, require_auth: bool):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
+    monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
+    monkeypatch.setenv("REQUIRE_AUTH", "true" if require_auth else "false")
+    import innerloop.settings as settings
+    importlib.reload(settings)
+    import innerloop.main as main
+    importlib.reload(main)
+    return main.app
+
+
+def test_post_optimize_requires_auth_in_prod_mode(monkeypatch):
+    app = _mkapp(monkeypatch, require_auth=True)
+    with TestClient(app) as client:
+        r = client.post("/v1/optimize", json={"prompt": "hi"})
+    assert r.status_code in (401, 403)
+
+
+def test_post_optimize_allowed_in_dev_mode(monkeypatch):
+    app = _mkapp(monkeypatch, require_auth=False)
+    with TestClient(app) as client:
+        r = client.post("/v1/optimize", json={"prompt": "hi"})
+    assert r.status_code in (200, 202, 400)

--- a/tests/test_backpressure.py
+++ b/tests/test_backpressure.py
@@ -21,9 +21,12 @@ def test_backpressure_failure(monkeypatch):
     importlib.reload(main)
     with TestClient(main.app) as client:
         headers = {"Authorization": "Bearer token"}
-        job_id = client.post("/v1/optimize", json={"prompt": "hi"}, params={"iterations": 2}, headers=headers).json()[
-            "job_id"
-        ]
+        job_id = client.post(
+            "/v1/optimize",
+            json={"prompt": "hi"},
+            params={"iterations": 2},
+            headers=headers,
+        ).json()["job_id"]
 
         # Never open the SSE stream; queue fills and job should fail
         deadline = time.time() + 3

--- a/tests/test_cancel_api.py
+++ b/tests/test_cancel_api.py
@@ -1,0 +1,34 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def _mkapp(monkeypatch):
+    """Create app with minimal auth so middleware passes."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
+    monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
+    import innerloop.settings as settings
+    importlib.reload(settings)
+    import innerloop.main as main
+    importlib.reload(main)
+    return main.app
+
+
+def test_cancel_returns_cancelled_status(monkeypatch):
+    app = _mkapp(monkeypatch)
+    client = TestClient(app)
+    with client:
+        resp = client.post(
+            "/v1/optimize",
+            json={"prompt": "hi"},
+            headers={"Authorization": "Bearer token"},
+            params={"iterations": 5},
+        )
+        assert resp.status_code == 200
+        job_id = resp.json()["job_id"]
+        got = client.delete(
+            f"/v1/optimize/{job_id}", headers={"Authorization": "Bearer token"}
+        )
+        assert got.status_code == 200
+        body = got.json()
+        assert body.get("status") == "cancelled"

--- a/tests/test_cancel_api.py
+++ b/tests/test_cancel_api.py
@@ -8,8 +8,10 @@ def _mkapp(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     return main.app
 

--- a/tests/test_config_tokens.py
+++ b/tests/test_config_tokens.py
@@ -1,0 +1,24 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def _mkapp(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
+    monkeypatch.setenv("API_BEARER_TOKENS", '["t1","t2"]')
+    import innerloop.settings as settings
+    importlib.reload(settings)
+    import innerloop.main as main
+    importlib.reload(main)
+    return main.app
+
+
+def test_multiple_bearer_tokens(monkeypatch):
+    app = _mkapp(monkeypatch)
+    with TestClient(app) as client:
+        r = client.post(
+            "/v1/optimize",
+            json={"prompt": "hi"},
+            headers={"Authorization": "Bearer t2"},
+        )
+    assert r.status_code in (200, 202, 400)

--- a/tests/test_config_tokens.py
+++ b/tests/test_config_tokens.py
@@ -7,8 +7,10 @@ def _mkapp(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     monkeypatch.setenv("API_BEARER_TOKENS", '["t1","t2"]')
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     return main.app
 

--- a/tests/test_eval_job.py
+++ b/tests/test_eval_job.py
@@ -6,6 +6,7 @@ def app_client(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     monkeypatch.setenv("USE_MODEL_STUB", "true")
     monkeypatch.setenv("REQUIRE_AUTH", "false")
+    monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     import innerloop.settings as settings
     importlib.reload(settings)
     import innerloop.main as main
@@ -22,13 +23,17 @@ def test_eval_flow(monkeypatch):
                 {"input": "great", "expected": "pos"},
                 {"input": "bad", "expected": "neg"},
             ],
+            headers={"Authorization": "Bearer token"},
         )
         job = c.post(
             "/v1/eval/start",
             json={"name": "baseline", "max_examples": 2, "seed": 7},
+            headers={"Authorization": "Bearer token"},
         ).json()["job_id"]
         events = set()
-        with c.stream("GET", f"/v1/eval/{job}/events") as s:
+        with c.stream(
+            "GET", f"/v1/eval/{job}/events", headers={"Authorization": "Bearer token"}
+        ) as s:
             it = s.iter_lines()
             next(it)
             for ln in it:

--- a/tests/test_eval_job.py
+++ b/tests/test_eval_job.py
@@ -1,4 +1,5 @@
 import importlib
+
 from fastapi.testclient import TestClient
 
 
@@ -8,8 +9,10 @@ def app_client(monkeypatch):
     monkeypatch.setenv("REQUIRE_AUTH", "false")
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     return TestClient(main.app)
 

--- a/tests/test_eval_target_model.py
+++ b/tests/test_eval_target_model.py
@@ -32,7 +32,9 @@ def test_evaluate_batch_threads_model():
 def test_gepa_uses_request_target_model(monkeypatch):
     seen = {"model": None}
 
-    async def fake_evaluate_batch(provider, candidate_prompt, examples, settings, model=None):
+    async def fake_evaluate_batch(
+        provider, candidate_prompt, examples, settings, model=None
+    ):
         seen["model"] = model
 
         class Res:
@@ -49,10 +51,14 @@ def test_gepa_uses_request_target_model(monkeypatch):
         return {}
 
     monkeypatch.setattr(gepa_loop, "run_reflection", fake_run_reflection)
-    monkeypatch.setattr(gepa_loop, "update_lessons_journal", lambda lessons, new: lessons)
+    monkeypatch.setattr(
+        gepa_loop, "update_lessons_journal", lambda lessons, new: lessons
+    )
     monkeypatch.setattr(gepa_loop, "apply_edits", lambda c, edits: c)
     monkeypatch.setattr(gepa_loop, "OPERATORS", {"reorder_sections": lambda c, rng: c})
-    monkeypatch.setattr(gepa_loop, "pareto_filter", lambda items, objectives=None, n=1: list(items))
+    monkeypatch.setattr(
+        gepa_loop, "pareto_filter", lambda items, objectives=None, n=1: list(items)
+    )
 
     async def fake_judge_scores(prompt, candidate, examples, objectives):
         return {"scores": {"overall": 8}}

--- a/tests/test_examples_crud.py
+++ b/tests/test_examples_crud.py
@@ -1,4 +1,5 @@
 import importlib
+
 from fastapi.testclient import TestClient
 
 
@@ -7,8 +8,10 @@ def app_client(monkeypatch):
     monkeypatch.setenv("REQUIRE_AUTH", "false")
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     return TestClient(main.app)
 
@@ -25,12 +28,11 @@ def test_examples_bulk_list_delete(monkeypatch):
             headers={"Authorization": "Bearer token"},
         )
         assert up.status_code == 200 and up.json()["upserted"] == 2
-        ls = c.get("/v1/examples", headers={"Authorization": "Bearer token"}).json()["examples"]
+        ls = c.get("/v1/examples", headers={"Authorization": "Bearer token"}).json()[
+            "examples"
+        ]
         assert len(ls) >= 2
         ex_id = ls[0]["id"]
-        assert (
-            c.delete(
-                f"/v1/examples/{ex_id}", headers={"Authorization": "Bearer token"}
-            ).status_code
-            in (200, 204)
-        )
+        assert c.delete(
+            f"/v1/examples/{ex_id}", headers={"Authorization": "Bearer token"}
+        ).status_code in (200, 204)

--- a/tests/test_examples_crud.py
+++ b/tests/test_examples_crud.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 def app_client(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     monkeypatch.setenv("REQUIRE_AUTH", "false")
+    monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     import innerloop.settings as settings
     importlib.reload(settings)
     import innerloop.main as main
@@ -21,9 +22,15 @@ def test_examples_bulk_list_delete(monkeypatch):
                 {"input": "I love it", "expected": "pos"},
                 {"input": "I hate it", "expected": "neg"},
             ],
+            headers={"Authorization": "Bearer token"},
         )
         assert up.status_code == 200 and up.json()["upserted"] == 2
-        ls = c.get("/v1/examples").json()["examples"]
+        ls = c.get("/v1/examples", headers={"Authorization": "Bearer token"}).json()["examples"]
         assert len(ls) >= 2
         ex_id = ls[0]["id"]
-        assert c.delete(f"/v1/examples/{ex_id}").status_code in (200, 204)
+        assert (
+            c.delete(
+                f"/v1/examples/{ex_id}", headers={"Authorization": "Bearer token"}
+            ).status_code
+            in (200, 204)
+        )

--- a/tests/test_examples_eval.py
+++ b/tests/test_examples_eval.py
@@ -1,10 +1,10 @@
 import asyncio
 import importlib
 
-import innerloop.settings as settings
 from innerloop.domain.engine import get_target_provider
-from innerloop.domain.examples import load_pack
 from innerloop.domain.eval import evaluate_batch
+from innerloop.domain.examples import load_pack
+import innerloop.settings as settings
 
 
 def test_example_pack_and_cache(monkeypatch):
@@ -12,7 +12,11 @@ def test_example_pack_and_cache(monkeypatch):
     importlib.reload(settings)
     provider = get_target_provider(settings.get_settings())
     pack = load_pack("toy_qa")
-    res1 = asyncio.run(evaluate_batch(provider, "answer:", pack.examples, settings.get_settings()))
+    res1 = asyncio.run(
+        evaluate_batch(provider, "answer:", pack.examples, settings.get_settings())
+    )
     assert set(res1.scores_by_example.keys()) == {"1", "2"}
-    res2 = asyncio.run(evaluate_batch(provider, "answer:", pack.examples, settings.get_settings()))
+    res2 = asyncio.run(
+        evaluate_batch(provider, "answer:", pack.examples, settings.get_settings())
+    )
     assert res2.cached

--- a/tests/test_gepa_diversity_objective.py
+++ b/tests/test_gepa_diversity_objective.py
@@ -9,9 +9,15 @@ def test_diversity_meta_and_selection(monkeypatch):
 
     monkeypatch.setattr(gepa_loop, "pareto_filter", fake_pareto)
 
-    cand_a = SimpleNamespace(id="A", sections=["solve by step one two three"], meta={"judge_score": 1.0})
-    cand_b = SimpleNamespace(id="B", sections=["solve by step one two three"], meta={"judge_score": 1.0})
-    cand_c = SimpleNamespace(id="C", sections=["completely different answer path"], meta={"judge_score": 1.0})
+    cand_a = SimpleNamespace(
+        id="A", sections=["solve by step one two three"], meta={"judge_score": 1.0}
+    )
+    cand_b = SimpleNamespace(
+        id="B", sections=["solve by step one two three"], meta={"judge_score": 1.0}
+    )
+    cand_c = SimpleNamespace(
+        id="C", sections=["completely different answer path"], meta={"judge_score": 1.0}
+    )
     scored = [cand_a, cand_b, cand_c]
 
     texts = ["\n".join(c.sections) for c in scored]

--- a/tests/test_gepa_events_alignment.py
+++ b/tests/test_gepa_events_alignment.py
@@ -28,8 +28,12 @@ def test_gepa_emits_selected(monkeypatch):
     monkeypatch.setattr(gepa_loop, "judge_scores", fake_judge_scores)
     monkeypatch.setattr(gepa_loop, "run_reflection", fake_run_reflection)
     monkeypatch.setattr(gepa_loop, "apply_edits", lambda cand, edits: cand)
-    monkeypatch.setattr(gepa_loop, "OPERATORS", {"reorder_sections": lambda c, rng=None: c})
-    monkeypatch.setattr(gepa_loop, "load_pack", lambda name: SimpleNamespace(examples=[]))
+    monkeypatch.setattr(
+        gepa_loop, "OPERATORS", {"reorder_sections": lambda c, rng=None: c}
+    )
+    monkeypatch.setattr(
+        gepa_loop, "load_pack", lambda name: SimpleNamespace(examples=[])
+    )
     monkeypatch.setattr(gepa_loop, "get_target_provider", lambda settings: None)
 
     payload = {

--- a/tests/test_gepa_loop_judge_participation.py
+++ b/tests/test_gepa_loop_judge_participation.py
@@ -12,7 +12,9 @@ def test_gepa_includes_judge_axis(monkeypatch):
 
     monkeypatch.setattr(gepa_loop, "judge_scores", fake_judge_scores)
 
-    async def fake_evaluate_batch(provider, candidate_prompt, examples, settings, model=None):
+    async def fake_evaluate_batch(
+        provider, candidate_prompt, examples, settings, model=None
+    ):
         class Res:
             mean_scores = {"exact_match": 1.0}
             cost = 0.0
@@ -27,7 +29,9 @@ def test_gepa_includes_judge_axis(monkeypatch):
         return {}
 
     monkeypatch.setattr(gepa_loop, "run_reflection", fake_run_reflection)
-    monkeypatch.setattr(gepa_loop, "update_lessons_journal", lambda lessons, new: lessons)
+    monkeypatch.setattr(
+        gepa_loop, "update_lessons_journal", lambda lessons, new: lessons
+    )
     monkeypatch.setattr(gepa_loop, "apply_edits", lambda c, edits: c)
     monkeypatch.setattr(gepa_loop, "OPERATORS", {"reorder_sections": lambda c, rng: c})
 
@@ -42,7 +46,11 @@ def test_gepa_includes_judge_axis(monkeypatch):
     async def emit(job, event, data):
         pass
 
-    payload = {"prompt": "hello", "dataset": {"name": "toy_qa"}, "budget": {"max_generations": 1}}
+    payload = {
+        "prompt": "hello",
+        "dataset": {"name": "toy_qa"},
+        "budget": {"max_generations": 1},
+    }
 
     async def main():
         await gepa_loop.gepa_loop(job=None, emit=emit, payload=payload)

--- a/tests/test_gepa_loop_roles.py
+++ b/tests/test_gepa_loop_roles.py
@@ -1,4 +1,5 @@
 import importlib
+
 from fastapi.testclient import TestClient
 import pytest
 
@@ -10,8 +11,10 @@ def test_gepa_loop_roles_and_lessons_sse(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     with TestClient(main.app) as client:
         # Start GEPA-mode optimize job
@@ -28,7 +31,9 @@ def test_gepa_loop_roles_and_lessons_sse(monkeypatch):
         job_id = resp.json()["job_id"]
         events = []
         with client.stream(
-            "GET", f"/optimize/{job_id}/events", headers={"Authorization": "Bearer token"}
+            "GET",
+            f"/optimize/{job_id}/events",
+            headers={"Authorization": "Bearer token"},
         ) as stream:
             for line in stream.iter_lines():
                 if not line:
@@ -47,4 +52,3 @@ def test_gepa_loop_roles_and_lessons_sse(monkeypatch):
         assert "reflection_started" in events
         assert "lessons_updated" in events
         assert "reflection_finished" in events
-

--- a/tests/test_gepa_loop_small.py
+++ b/tests/test_gepa_loop_small.py
@@ -1,7 +1,7 @@
 import importlib
 
-import pytest
 from fastapi.testclient import TestClient
+import pytest
 
 
 @pytest.mark.timeout(10)
@@ -9,8 +9,10 @@ def test_gepa_loop_sse(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     with TestClient(main.app) as client:
         resp = client.post(
@@ -25,7 +27,9 @@ def test_gepa_loop_sse(monkeypatch):
         job_id = resp.json()["job_id"]
         events = []
         with client.stream(
-            "GET", f"/optimize/{job_id}/events", headers={"Authorization": "Bearer token"}
+            "GET",
+            f"/optimize/{job_id}/events",
+            headers={"Authorization": "Bearer token"},
         ) as stream:
             for line in stream.iter_lines():
                 if line.startswith("event:"):

--- a/tests/test_healthz.py
+++ b/tests/test_healthz.py
@@ -6,8 +6,10 @@ from fastapi.testclient import TestClient
 def test_healthz(monkeypatch):
     monkeypatch.delenv("API_BEARER_TOKENS", raising=False)
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     with TestClient(main.app) as client:
         response = client.get("/healthz")
@@ -17,10 +19,13 @@ def test_healthz(monkeypatch):
 
 def test_healthz_v1(monkeypatch):
     monkeypatch.delenv("API_BEARER_TOKENS", raising=False)
-    import innerloop.settings as settings
     import importlib
+
+    import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     with TestClient(main.app) as client:
         resp_root = client.get("/healthz")

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -7,8 +7,10 @@ def test_idempotent_job_creation(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
     monkeypatch.delenv("API_BEARER_TOKENS", raising=False)
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     from innerloop.api import metrics
 

--- a/tests/test_judge_cache.py
+++ b/tests/test_judge_cache.py
@@ -1,5 +1,6 @@
-import importlib
 import asyncio
+import importlib
+
 from innerloop.api.jobs.store import MemoryJobStore
 
 
@@ -7,6 +8,7 @@ def test_judge_cache(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     monkeypatch.setenv("USE_MODEL_STUB", "true")
     import innerloop.domain.judge as judge
+
     importlib.reload(judge)
     store = MemoryJobStore()
 

--- a/tests/test_judge_config_headers.py
+++ b/tests/test_judge_config_headers.py
@@ -6,8 +6,10 @@ def reload_engine(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "x")
     monkeypatch.setenv("OPENAI_API_KEY", "y")
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.domain.engine as engine
+
     importlib.reload(engine)
     return engine
 

--- a/tests/test_judge_fallback.py
+++ b/tests/test_judge_fallback.py
@@ -22,7 +22,9 @@ class _BadJsonProvider:
 
 
 async def test_judge_fallback_on_provider_error(monkeypatch):
-    monkeypatch.setattr(judge_mod, "get_judge_provider", lambda *a, **k: _FailingProvider())
+    monkeypatch.setattr(
+        judge_mod, "get_judge_provider", lambda *a, **k: _FailingProvider()
+    )
     start = metrics.snapshot_metrics_json().get("judge_failures", 0)
     res = await judge_mod.judge(task="t", a="short", b="longer content")
     assert res["winner"] in {"A", "B"}
@@ -32,7 +34,9 @@ async def test_judge_fallback_on_provider_error(monkeypatch):
 
 
 async def test_judge_fallback_on_invalid_json(monkeypatch):
-    monkeypatch.setattr(judge_mod, "get_judge_provider", lambda *a, **k: _BadJsonProvider())
+    monkeypatch.setattr(
+        judge_mod, "get_judge_provider", lambda *a, **k: _BadJsonProvider()
+    )
     start = metrics.snapshot_metrics_json().get("judge_failures", 0)
     res = await judge_mod.judge(task="t", a="short", b="much longer text than a")
     assert res["winner"] in {"A", "B"}

--- a/tests/test_judge_lock.py
+++ b/tests/test_judge_lock.py
@@ -8,8 +8,10 @@ def test_judge_is_locked(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     monkeypatch.setenv("USE_MODEL_STUB", "true")
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.domain.judge as judge
+
     importlib.reload(judge)
     store = MemoryJobStore()
     before = judge.CALLS

--- a/tests/test_judge_scores_fallback_metric.py
+++ b/tests/test_judge_scores_fallback_metric.py
@@ -2,9 +2,9 @@ import importlib
 
 import pytest
 
-import innerloop.settings as settings
 from innerloop.api import metrics
 from innerloop.domain import judge as dj
+import innerloop.settings as settings
 
 pytestmark = pytest.mark.anyio
 
@@ -24,7 +24,9 @@ async def test_judge_scores_increments_metric_on_bad_json(monkeypatch):
     importlib.reload(settings)
     monkeypatch.setattr(dj, "get_judge_provider", lambda s: BadJsonProvider())
     start = metrics.snapshot_metrics_json().get("judge_failures", 0)
-    out = await dj.judge_scores(prompt="p", candidate="c", examples=None, objectives=["brevity"])
+    out = await dj.judge_scores(
+        prompt="p", candidate="c", examples=None, objectives=["brevity"]
+    )
     end = metrics.snapshot_metrics_json().get("judge_failures", 0)
     assert end == start + 1
     assert out.get("unavailable") is True

--- a/tests/test_judge_stub.py
+++ b/tests/test_judge_stub.py
@@ -1,5 +1,5 @@
-import importlib
 import asyncio
+import importlib
 
 from innerloop.domain.judge import get_judge
 import innerloop.settings as settings
@@ -15,4 +15,3 @@ def test_judge_stub_ranking(monkeypatch):
     items = [p for p, _ in ranked]
     assert set(items) == set(proposals)
     assert items[0] in {"short good", "mid"}
-

--- a/tests/test_judge_stub_and_target.py
+++ b/tests/test_judge_stub_and_target.py
@@ -1,8 +1,8 @@
 import importlib
 import json
 
-import pytest
 from fastapi.testclient import TestClient
+import pytest
 
 
 @pytest.mark.timeout(5)
@@ -12,8 +12,10 @@ def test_judge_stub_and_target(monkeypatch):
     monkeypatch.setenv("USE_MODEL_STUB", "true")
     monkeypatch.setenv("JUDGE_MODEL_ID", "openai:gpt-5-judge")
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     body = {
         "prompt": "say hi",
@@ -30,7 +32,9 @@ def test_judge_stub_and_target(monkeypatch):
         assert resp.status_code == 200
         job_id = resp.json()["job_id"]
         with client.stream(
-            "GET", f"/v1/optimize/{job_id}/events", headers={"Authorization": "Bearer token"}
+            "GET",
+            f"/v1/optimize/{job_id}/events",
+            headers={"Authorization": "Bearer token"},
         ) as stream:
             line_iter = stream.iter_lines()
             first = next(line_iter)
@@ -52,7 +56,9 @@ def test_judge_stub_and_target(monkeypatch):
         resp2 = client.post("/v1/optimize", json=body, params={"iterations": 2})
         job2 = resp2.json()["job_id"]
         with client.stream(
-            "GET", f"/v1/optimize/{job2}/events", headers={"Authorization": "Bearer token"}
+            "GET",
+            f"/v1/optimize/{job2}/events",
+            headers={"Authorization": "Bearer token"},
         ) as stream:
             for line in stream.iter_lines():
                 if line.startswith("data:"):

--- a/tests/test_logging_redaction.py
+++ b/tests/test_logging_redaction.py
@@ -35,4 +35,3 @@ def test_authorization_header_redacted(monkeypatch, caplog):
                 assert val == "REDACTED"
                 redacted_seen = True
     assert redacted_seen, "no Authorization header captured on record"
-

--- a/tests/test_metrics_prom.py
+++ b/tests/test_metrics_prom.py
@@ -1,12 +1,15 @@
 import importlib
+
 from fastapi.testclient import TestClient
 
 
 def test_metrics_snapshot(monkeypatch):
     monkeypatch.delenv("API_BEARER_TOKENS", raising=False)
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     with TestClient(main.app) as client:
         r = client.get("/v1/healthz")

--- a/tests/test_metrics_text.py
+++ b/tests/test_metrics_text.py
@@ -15,4 +15,7 @@ def test_metrics_text_endpoint(monkeypatch):
         body = resp.text
         assert len(body) > 0
         # Heuristic: Prometheus format often includes HELP/TYPE or metric name
-        assert any(token in body.lower() for token in ["help", "type", "requests_total", "judge_stub_used"])
+        assert any(
+            token in body.lower()
+            for token in ["help", "type", "requests_total", "judge_stub_used"]
+        )

--- a/tests/test_metrics_text_types.py
+++ b/tests/test_metrics_text_types.py
@@ -1,0 +1,22 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def _mkapp(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
+    monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
+    import innerloop.settings as settings
+    importlib.reload(settings)
+    import innerloop.main as main
+    importlib.reload(main)
+    return main.app
+
+
+def test_metrics_types(monkeypatch):
+    app = _mkapp(monkeypatch)
+    with TestClient(app) as client:
+        r = client.get("/v1/metrics")
+    assert r.status_code == 200
+    text = r.text
+    assert "# TYPE sse_clients gauge" in text

--- a/tests/test_metrics_text_types.py
+++ b/tests/test_metrics_text_types.py
@@ -7,8 +7,10 @@ def _mkapp(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     return main.app
 

--- a/tests/test_nemesis.py
+++ b/tests/test_nemesis.py
@@ -2,8 +2,8 @@ import importlib
 import json
 import time
 
-import pytest
 from fastapi.testclient import TestClient
+import pytest
 
 
 @pytest.mark.timeout(5)
@@ -73,4 +73,7 @@ def test_stalled_consumer_triggers_backpressure(monkeypatch):
             time.sleep(0.7)  # stall reading to overflow queue
             lines = [ln for ln in stream.iter_lines() if ln.startswith("data:")]
     terminals = [json.loads(ln[5:].strip()) for ln in lines]
-    assert any(env["type"] == "failed" and env["data"].get("error") == "sse_backpressure" for env in terminals)
+    assert any(
+        env["type"] == "failed" and env["data"].get("error") == "sse_backpressure"
+        for env in terminals
+    )

--- a/tests/test_no_blocking_in_endpoints.py
+++ b/tests/test_no_blocking_in_endpoints.py
@@ -7,6 +7,7 @@ FORBIDDEN = [
     r"\baiohttp\.ClientSession\(",
 ]
 
+
 def test_no_blocking_http_in_endpoints():
     root = pathlib.Path(__file__).resolve().parents[1]
     routers = root / "innerloop" / "api" / "routers"

--- a/tests/test_optimize_examples_objectives.py
+++ b/tests/test_optimize_examples_objectives.py
@@ -1,8 +1,8 @@
 import importlib
 import json
 
-import pytest
 from fastapi.testclient import TestClient
+import pytest
 
 
 def create_client(monkeypatch):
@@ -10,8 +10,10 @@ def create_client(monkeypatch):
     monkeypatch.setenv("USE_MODEL_STUB", "true")
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     return TestClient(main.app)
 
@@ -30,7 +32,9 @@ def test_optimize_examples_objectives(monkeypatch):
         assert resp.status_code == 200
         job_id = resp.json()["job_id"]
         with client.stream(
-            "GET", f"/v1/optimize/{job_id}/events", headers={"Authorization": "Bearer token"}
+            "GET",
+            f"/v1/optimize/{job_id}/events",
+            headers={"Authorization": "Bearer token"},
         ) as stream:
             line_iter = stream.iter_lines()
             first = next(line_iter)
@@ -38,7 +42,7 @@ def test_optimize_examples_objectives(monkeypatch):
             progress_seen = False
             finished_scores = None
             for line in line_iter:
-                if line.startswith("data:" ):
+                if line.startswith("data:"):
                     env = json.loads(line.split(":", 1)[1])
                     if env["type"] == "progress" and "scores" in env["data"]:
                         progress_seen = True
@@ -47,16 +51,24 @@ def test_optimize_examples_objectives(monkeypatch):
                         break
             assert progress_seen
             assert finished_scores is not None
-            assert all(k in finished_scores for k in ["brevity", "diversity", "coverage"])
+            assert all(
+                k in finished_scores for k in ["brevity", "diversity", "coverage"]
+            )
         # determinism with seed
-        resp1 = client.post("/v1/optimize", json={**body, "seed": 123}, params={"iterations": 1})
-        resp2 = client.post("/v1/optimize", json={**body, "seed": 123}, params={"iterations": 1})
+        resp1 = client.post(
+            "/v1/optimize", json={**body, "seed": 123}, params={"iterations": 1}
+        )
+        resp2 = client.post(
+            "/v1/optimize", json={**body, "seed": 123}, params={"iterations": 1}
+        )
         job1 = resp1.json()["job_id"]
         job2 = resp2.json()["job_id"]
         props = []
         for job in (job1, job2):
             with client.stream(
-                "GET", f"/v1/optimize/{job}/events", headers={"Authorization": "Bearer token"}
+                "GET",
+                f"/v1/optimize/{job}/events",
+                headers={"Authorization": "Bearer token"},
             ) as stream:
                 line_iter = stream.iter_lines()
                 next(line_iter)

--- a/tests/test_optimize_sse.py
+++ b/tests/test_optimize_sse.py
@@ -1,7 +1,7 @@
 import importlib
 
-import pytest
 from fastapi.testclient import TestClient
+import pytest
 
 
 @pytest.mark.timeout(5)
@@ -9,8 +9,10 @@ def test_optimize_sse(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     with TestClient(main.app) as client:
         resp = client.post("/optimize", json={"prompt": "hi"}, params={"iterations": 1})
@@ -18,7 +20,9 @@ def test_optimize_sse(monkeypatch):
         job_id = resp.json()["job_id"]
 
         with client.stream(
-            "GET", f"/optimize/{job_id}/events", headers={"Authorization": "Bearer token"}
+            "GET",
+            f"/optimize/{job_id}/events",
+            headers={"Authorization": "Bearer token"},
         ) as stream:
             line_iter = stream.iter_lines()
             first = next(line_iter)

--- a/tests/test_pareto_v2.py
+++ b/tests/test_pareto_v2.py
@@ -1,17 +1,19 @@
-import importlib
 import asyncio
+import importlib
 import json
 
-import pytest
 from fastapi.testclient import TestClient
+import pytest
 
 
 def test_judge_based_selection(monkeypatch):
     monkeypatch.setenv("USE_JUDGE_STUB", "true")
     monkeypatch.setenv("ENABLE_PARETO_V2", "true")
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.domain.optimize_engine as oe
+
     importlib.reload(oe)
     proposals = ["longer proposal here", "short"]
     best = asyncio.run(
@@ -27,10 +29,13 @@ def test_rubric_and_target_propagation_in_stream(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.api.models as api_models
+
     importlib.reload(api_models)
     import innerloop.main as main
+
     importlib.reload(main)
     with TestClient(main.app) as client:
         r = client.post(

--- a/tests/test_perf_budgets.py
+++ b/tests/test_perf_budgets.py
@@ -7,12 +7,16 @@ def test_perf_budgets(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     monkeypatch.setenv("GEPA_DETERMINISTIC", "true")
     import innerloop.settings as settings
+
     importlib.reload(settings)
     s = settings.get_settings()
     import innerloop.main as main
+
     importlib.reload(main)
     with TestClient(main.app) as client:
-        job_id = client.post("/v1/optimize", json={"prompt":"x"}, params={"iterations":2}).json()["job_id"]
+        job_id = client.post(
+            "/v1/optimize", json={"prompt": "x"}, params={"iterations": 2}
+        ).json()["job_id"]
         with client.stream("GET", f"/v1/optimize/{job_id}/events") as stream:
             for line in stream.iter_lines():
                 if line.startswith("event: finished"):

--- a/tests/test_perf_json.py
+++ b/tests/test_perf_json.py
@@ -1,5 +1,6 @@
 from innerloop.api.sse import format_sse
 
+
 def test_format_sse_compact_json():
     env = {"id": 1, "job_id": "j", "ts": 0.0, "data": {"x": 1}}
     text = format_sse("progress", env)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -44,7 +44,11 @@ def test_pareto_invariants(items: List[str], n: int) -> None:
                 assert not _dominates(sj, si)
 
 
-@hsettings(max_examples=20, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@hsettings(
+    max_examples=20,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
 @given(st.integers(min_value=1, max_value=3))
 def test_sse_invariants(monkeypatch, iterations: int) -> None:
     # auth bypass for /optimize
@@ -59,10 +63,15 @@ def test_sse_invariants(monkeypatch, iterations: int) -> None:
     with TestClient(main.app) as client:
         headers = {"Authorization": "Bearer token"}
         job_id = client.post(
-            "/v1/optimize", json={"prompt": "x"}, params={"iterations": iterations}, headers=headers
+            "/v1/optimize",
+            json={"prompt": "x"},
+            params={"iterations": iterations},
+            headers=headers,
         ).json()["job_id"]
 
-        with client.stream("GET", f"/v1/optimize/{job_id}/events", headers=headers) as stream:
+        with client.stream(
+            "GET", f"/v1/optimize/{job_id}/events", headers=headers
+        ) as stream:
             it = stream.iter_lines()
             first = next(it)
             assert first.startswith("retry:")
@@ -97,11 +106,16 @@ def test_sse_golden_sequence(monkeypatch) -> None:
     importlib.reload(main)
     with TestClient(main.app) as client:
         headers = {"Authorization": "Bearer token"}
-        job_id = client.post("/v1/optimize", json={"prompt": "hi"}, params={"iterations": 1}, headers=headers).json()[
-            "job_id"
-        ]
+        job_id = client.post(
+            "/v1/optimize",
+            json={"prompt": "hi"},
+            params={"iterations": 1},
+            headers=headers,
+        ).json()["job_id"]
 
-        with client.stream("GET", f"/v1/optimize/{job_id}/events", headers=headers) as stream:
+        with client.stream(
+            "GET", f"/v1/optimize/{job_id}/events", headers=headers
+        ) as stream:
             it = stream.iter_lines()
             next(it)  # retry prelude
             seen: list[str] = []

--- a/tests/test_provider_lifecycle.py
+++ b/tests/test_provider_lifecycle.py
@@ -8,6 +8,7 @@ def test_provider_singleton(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     monkeypatch.setenv("USE_MODEL_STUB", "false")
     import innerloop.settings as settings
+
     importlib.reload(settings)
     importlib.reload(eng)
     p1 = eng.get_provider_from_env()
@@ -19,8 +20,10 @@ def test_provider_close(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     monkeypatch.setenv("USE_MODEL_STUB", "false")
     import innerloop.settings as settings
+
     importlib.reload(settings)
     from innerloop.domain import engine as eng
+
     p = eng.get_provider_from_env()
     assert p is eng.get_provider_from_env()
     asyncio.run(eng.close_provider())

--- a/tests/test_provider_select.py
+++ b/tests/test_provider_select.py
@@ -1,6 +1,5 @@
-import importlib
-
 import asyncio
+import importlib
 
 
 def reload_env(monkeypatch, **env):
@@ -10,14 +9,21 @@ def reload_env(monkeypatch, **env):
         else:
             monkeypatch.setenv(k, str(v))
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.domain.engine as engine
+
     importlib.reload(engine)
     import innerloop.domain.reflection_runner as runner
+
     importlib.reload(runner)
     return engine, runner
+
+
 def test_default_local_echo(monkeypatch):
-    engine, runner = reload_env(monkeypatch, OPENROUTER_API_KEY=None, USE_MODEL_STUB=True)
+    engine, runner = reload_env(
+        monkeypatch, OPENROUTER_API_KEY=None, USE_MODEL_STUB=True
+    )
     provider = engine.get_target_provider()
     assert isinstance(provider, engine.LocalEchoProvider)
     result = asyncio.run(runner.run_reflection("hello", "default", 0))
@@ -25,7 +31,9 @@ def test_default_local_echo(monkeypatch):
 
 
 def test_stub_false_without_key(monkeypatch):
-    engine, runner = reload_env(monkeypatch, OPENROUTER_API_KEY=None, USE_MODEL_STUB="false")
+    engine, runner = reload_env(
+        monkeypatch, OPENROUTER_API_KEY=None, USE_MODEL_STUB="false"
+    )
     provider = engine.get_target_provider()
     assert isinstance(provider, engine.LocalEchoProvider)
     result = asyncio.run(runner.run_reflection("hi", "default", 0))
@@ -33,7 +41,9 @@ def test_stub_false_without_key(monkeypatch):
 
 
 def test_openrouter_provider(monkeypatch):
-    engine, runner = reload_env(monkeypatch, OPENROUTER_API_KEY="fake", USE_MODEL_STUB="false")
+    engine, runner = reload_env(
+        monkeypatch, OPENROUTER_API_KEY="fake", USE_MODEL_STUB="false"
+    )
     provider = engine.get_target_provider()
     assert isinstance(provider, engine.OpenRouterProvider)
     result = asyncio.run(runner.run_reflection("hi", "default", 0))

--- a/tests/test_python_client.py
+++ b/tests/test_python_client.py
@@ -1,7 +1,7 @@
-import importlib
-import sys
-import pathlib
 import asyncio
+import importlib
+import pathlib
+import sys
 
 import httpx
 import pytest
@@ -22,8 +22,10 @@ async def gepa_client(monkeypatch) -> GepaClient:
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     async with main.app.router.lifespan_context(main.app):
         transport = httpx.ASGITransport(app=main.app)

--- a/tests/test_rate_headers.py
+++ b/tests/test_rate_headers.py
@@ -1,4 +1,5 @@
 import importlib
+
 from fastapi.testclient import TestClient
 
 
@@ -6,7 +7,7 @@ def test_retry_after_present(monkeypatch):
     client = TestClient(_mkapp(monkeypatch))
     with client:
         for _ in range(5):
-            resp = client.post("/optimize", json={"prompt":"hi"})
+            resp = client.post("/optimize", json={"prompt": "hi"})
         last = resp
         assert last.status_code in (200, 429)
         if last.status_code == 429:
@@ -19,7 +20,9 @@ def _mkapp(monkeypatch):
     monkeypatch.setenv("RATE_LIMIT_OPTIMIZE_RPS", "1")
     monkeypatch.setenv("RATE_LIMIT_OPTIMIZE_BURST", "1")
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     return main.app

--- a/tests/test_reflection_runner_modes.py
+++ b/tests/test_reflection_runner_modes.py
@@ -5,14 +5,16 @@ import importlib
 def test_run_reflection_modes_stub(monkeypatch):
     monkeypatch.setenv("USE_MODEL_STUB", "true")
     import innerloop.domain.reflection_runner as rr
+
     importlib.reload(rr)
     base = "Prompt base"
     ex = [{"input": "foo", "expected": "bar"}]
     for i, mode in enumerate(["author", "reviewer", "planner", "revision"]):
         res = asyncio.run(
-            rr.run_reflection(base, mode, i, examples=ex, target_model="openai:gpt-4o-mini")
+            rr.run_reflection(
+                base, mode, i, examples=ex, target_model="openai:gpt-4o-mini"
+            )
         )
         assert res["mode"] == mode
         assert isinstance(res["lessons"], list) and res["lessons"]
         assert isinstance(res["edits"], list)
-

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,12 +1,15 @@
 import importlib
+
 from fastapi.testclient import TestClient
 
 
 def test_retrieval_influences_context(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     with TestClient(main.app) as client:
         r = client.post(

--- a/tests/test_security_perf.py
+++ b/tests/test_security_perf.py
@@ -29,7 +29,7 @@ def test_sse_headers(monkeypatch):
             f"/optimize/{job_id}/events",
             headers={"Authorization": "Bearer token"},
         )
-        assert resp.headers["cache-control"] == "no-store"
+        assert resp.headers["cache-control"] in {"no-store", "no-cache"}
         assert resp.headers["connection"] == "keep-alive"
         assert resp.headers["x-accel-buffering"] == "no"
 

--- a/tests/test_sse_headers.py
+++ b/tests/test_sse_headers.py
@@ -9,8 +9,10 @@ def _mkapp(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     return main.app
 

--- a/tests/test_sse_headers.py
+++ b/tests/test_sse_headers.py
@@ -1,0 +1,42 @@
+import importlib
+import re
+
+from fastapi.testclient import TestClient
+
+
+def _mkapp(monkeypatch):
+    """Create app with minimal auth to avoid middleware rejection."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
+    monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
+    import innerloop.settings as settings
+    importlib.reload(settings)
+    import innerloop.main as main
+    importlib.reload(main)
+    return main.app
+
+
+def test_sse_headers_and_prelude(monkeypatch):
+    app = _mkapp(monkeypatch)
+    client = TestClient(app)
+    with client:
+        resp = client.post(
+            "/v1/optimize",
+            json={"prompt": "hi"},
+            headers={"Authorization": "Bearer token"},
+            params={"iterations": 1},
+        )
+        assert resp.status_code == 200
+        job_id = resp.json()["job_id"]
+        with client.stream(
+            "GET",
+            f"/v1/optimize/{job_id}/events",
+            headers={"Authorization": "Bearer token"},
+        ) as stream:
+            headers = {k.lower(): v for k, v in stream.headers.items()}
+            assert headers.get("content-type", "").startswith("text/event-stream")
+            assert headers.get("x-accel-buffering") == "no"
+            assert "cache-control" in headers and re.search(
+                r"no-(cache|store)", headers["cache-control"]
+            )
+            first = next(stream.iter_lines())
+            assert first.startswith("retry:")

--- a/tests/test_sse_resume.py
+++ b/tests/test_sse_resume.py
@@ -1,7 +1,7 @@
 import importlib
 
-import pytest
 from fastapi.testclient import TestClient
+import pytest
 
 
 @pytest.mark.timeout(5)
@@ -9,15 +9,21 @@ def test_sse_resume(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     with TestClient(main.app) as client:
-        resp = client.post("/v1/optimize", json={"prompt": "hi"}, params={"iterations": 3})
+        resp = client.post(
+            "/v1/optimize", json={"prompt": "hi"}, params={"iterations": 3}
+        )
         job_id = resp.json()["job_id"]
 
         with client.stream(
-            "GET", f"/v1/optimize/{job_id}/events", headers={"Authorization": "Bearer token"}
+            "GET",
+            f"/v1/optimize/{job_id}/events",
+            headers={"Authorization": "Bearer token"},
         ) as stream:
             lines = stream.iter_lines()
             next(lines)  # retry prelude

--- a/tests/test_store_sqlite.py
+++ b/tests/test_store_sqlite.py
@@ -1,8 +1,8 @@
 import importlib
 import time
 
-import pytest
 from fastapi.testclient import TestClient
+import pytest
 
 
 @pytest.mark.parametrize("store", ["memory", "sqlite"])
@@ -13,8 +13,10 @@ def test_persistence_across_reload(monkeypatch, tmp_path, store):
     monkeypatch.setenv("OPENROUTER_API_KEY", "test")
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     with TestClient(main.app) as client:
         headers = {"Idempotency-Key": "abc"}
@@ -39,7 +41,9 @@ def test_persistence_across_reload(monkeypatch, tmp_path, store):
     with TestClient(main.app) as client2:
         if store == "sqlite":
             with client2.stream(
-                "GET", f"/v1/optimize/{job_id}/events", headers={"Authorization": "Bearer token"}
+                "GET",
+                f"/v1/optimize/{job_id}/events",
+                headers={"Authorization": "Bearer token"},
             ) as stream:
                 lines = stream.iter_lines()
                 next(lines)

--- a/tests/test_target_model.py
+++ b/tests/test_target_model.py
@@ -8,8 +8,10 @@ def test_target_model_roundtrip(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     with TestClient(main.app) as client:
         r = client.post(
@@ -46,8 +48,10 @@ def test_target_model_default(monkeypatch):
     monkeypatch.setenv("API_BEARER_TOKENS", '["token"]')
     monkeypatch.setenv("TARGET_MODEL_DEFAULT", "default-model")
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     with TestClient(main.app) as client:
         job_id = client.post("/v1/optimize", json={"prompt": "hello"}).json()["job_id"]
@@ -64,4 +68,3 @@ def test_target_model_default(monkeypatch):
             headers={"Authorization": "Bearer token"},
         ).json()
         assert state["result"]["target_model"] == "default-model"
-

--- a/tests/test_tournament_and_early_stop.py
+++ b/tests/test_tournament_and_early_stop.py
@@ -1,4 +1,5 @@
 import importlib
+
 from fastapi.testclient import TestClient
 
 
@@ -9,8 +10,10 @@ def reload_env(monkeypatch, **env):
         else:
             monkeypatch.setenv(k, str(v))
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     return main
 
@@ -37,7 +40,9 @@ def test_early_stop_and_events(monkeypatch):
         job = r.json()["job_id"]
         saw = set()
         with client.stream(
-            "GET", f"/v1/optimize/{job}/events", headers={"Authorization": "Bearer token"}
+            "GET",
+            f"/v1/optimize/{job}/events",
+            headers={"Authorization": "Bearer token"},
         ) as s:
             for ln in s.iter_lines():
                 if ln.startswith("event:"):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,13 +1,17 @@
 import importlib
+
 from fastapi.testclient import TestClient
+
 
 def test_iterations_min(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "dev")
     import innerloop.settings as settings
+
     importlib.reload(settings)
     import innerloop.main as main
+
     importlib.reload(main)
     with TestClient(main.app) as client:
-        r = client.post("/v1/optimize", json={"prompt":"hi"}, params={"iterations":0})
+        r = client.post("/v1/optimize", json={"prompt": "hi"}, params={"iterations": 0})
         assert r.status_code == 422
         assert r.json()["error"]["code"] == "validation_error"

--- a/tools/load_sse.py
+++ b/tools/load_sse.py
@@ -18,11 +18,16 @@ logging.basicConfig(level=logging.INFO)
 async def run_client(base_url: str, iterations: int, stats: List[float]) -> None:
     async with httpx.AsyncClient(base_url=base_url) as client:
         start = time.perf_counter()
-        r = await client.post("/v1/optimize", json={"prompt": "hi"}, params={"iterations": iterations})
+        r = await client.post(
+            "/v1/optimize", json={"prompt": "hi"}, params={"iterations": iterations}
+        )
         job_id = r.json()["job_id"]
         async with client.stream("GET", f"/v1/optimize/{job_id}/events") as resp:
             async for line in resp.aiter_lines():
-                if line.startswith("event:") and line.split(":", 1)[1].strip() in TERMINALS:
+                if (
+                    line.startswith("event:")
+                    and line.split(":", 1)[1].strip() in TERMINALS
+                ):
                     break
         stats.append(time.perf_counter() - start)
 
@@ -33,7 +38,9 @@ async def main() -> None:
     parser.add_argument("--iterations", type=int, default=1)
     parser.add_argument("--duration", type=int, default=30)
     parser.add_argument("--base-url", default="http://localhost:8000")
-    parser.add_argument("--json", action="store_true", help="emit results as JSON to stdout")
+    parser.add_argument(
+        "--json", action="store_true", help="emit results as JSON to stdout"
+    )
     args = parser.parse_args()
 
     latencies: List[float] = []

--- a/tools/snapshot_openapi.py
+++ b/tools/snapshot_openapi.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from pathlib import Path
+import sys
 
 from innerloop.main import app
 
@@ -37,7 +37,9 @@ def main() -> int:
 
     old = SNAP_PATH.read_text(encoding="utf-8")
     if old != data:
-        print("[snapshot-openapi] OpenAPI drift detected. Run with --update to refresh snapshot.")
+        print(
+            "[snapshot-openapi] OpenAPI drift detected. Run with --update to refresh snapshot."
+        )
         return 1
 
     print("[snapshot-openapi] snapshot OK")

--- a/tools/sse_inspect.py
+++ b/tools/sse_inspect.py
@@ -8,6 +8,7 @@ import sys
 import anyio
 import httpx
 
+
 async def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--base-url", default="http://localhost:8000")
@@ -16,8 +17,12 @@ async def main():
     ap.add_argument("--timeout", type=float, default=30.0)
     args = ap.parse_args()
     headers = {"Last-Event-ID": str(args.last_id)} if args.last_id else {}
-    async with httpx.AsyncClient(base_url=args.base_url, timeout=args.timeout) as client:
-        async with client.stream("GET", f"/v1/optimize/{args.job_id}/events", headers=headers) as resp:
+    async with httpx.AsyncClient(
+        base_url=args.base_url, timeout=args.timeout
+    ) as client:
+        async with client.stream(
+            "GET", f"/v1/optimize/{args.job_id}/events", headers=headers
+        ) as resp:
             async for line in resp.aiter_lines():
                 if line.startswith("id:") or line.startswith("event:"):
                     print(line)
@@ -30,6 +35,7 @@ async def main():
                 elif line == ":":
                     print("(ping)")
                 sys.stdout.flush()
+
 
 if __name__ == "__main__":
     anyio.run(main)


### PR DESCRIPTION
## Summary
- Add `python -m innerloop` CLI with `--dev` flag and update Makefile run target
- Restrict auth bypass to dev POST /optimize and isolate unauth rate-limit buckets per client
- Improve SSE stream headers, cancellation response, metrics types, documentation, and fix ruff lint errors
- Default CLI host to loopback 127.0.0.1 and document HOST/PORT env vars
- Introduce black/isort formatting config and split workflow into check-only for PRs and auto-fix on push

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e0cefae2883328cf14ffe1ec99ff6